### PR TITLE
docs: seed planning, architecture, and roadmap

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -1,0 +1,27 @@
+# Binaries
+/bin/
+/dist/
+nf
+nfd
+nf-api
+
+# Go
+*.test
+*.out
+/coverage.txt
+/vendor/
+
+# IDE
+.idea/
+.vscode/
+*.swp
+
+# OS
+.DS_Store
+Thumbs.db
+
+# Local data
+*.db
+*.db-shm
+*.db-wal
+/.night-family/local/

--- a/README.md
+++ b/README.md
@@ -1,0 +1,106 @@
+# night-family
+
+> *"Wubba lubba dub dub — we've got work to do."*
+
+**night-family** is a crew of AI agents that clock in after you clock out. Each
+one has a role, a set of duties, and a system prompt you control. They run
+during a configurable nightly window (default **22:00 → 05:00 local**), chew
+through the leftover tokens in your Claude session, and — by morning — hand you
+a stack of small, reviewable PRs with `@coderabbitai` and `@cubic-dev-ai`
+already tagged for review.
+
+Inspired by Rick & Morty. Not affiliated.
+
+---
+
+## Why
+
+You have a codebase. You have a long list of never-quite-urgent chores:
+
+- docs drift further from reality every week
+- a release-notes draft that never gets started
+- test coverage that slowly rots
+- dependency bumps that pile up
+- the vague suspicion there's a security issue you'd find if you looked
+
+You also have a Claude subscription that resets every 5 hours whether you use
+it or not. night-family is the answer to *"why aren't those tokens working
+on my codebase while I sleep?"*
+
+## What it does (at a glance)
+
+- Wakes at a configured time (default 22:00 local)
+- Reads the remaining Claude session budget
+- Plans the night: which family members run, which duties, in what order
+- For each duty: creates a branch, runs the agent, commits, pushes, opens a
+  small PR, tags reviewers (configurable)
+- Never commits to `main` — every change is PR-gated
+- Stops at window-end or when budget is exhausted
+- Stores everything (runs, PRs, budget snapshots) in a local SQLite DB
+
+In the morning you open GitHub and triage.
+
+## Who's in the family
+
+Family members are **just YAML files** — a role, a system prompt, a list of
+duties, a risk tolerance. The defaults ship with:
+
+| Member      | Role                                   |
+|-------------|----------------------------------------|
+| Rick        | Security / vulnerability hunter        |
+| Morty       | Docs & release notes                   |
+| Summer      | Test coverage & flaky-test detection   |
+| Beth        | Refactor, dead-code, code health       |
+| Jerry       | Low-risk chores: lint, typos, deps     |
+| Birdperson  | Signals from metrics & logs            |
+| Squanchy    | Exploratory / wildcard                 |
+
+Want a `Mr. Meeseeks` that exists only to clear one backlog of TODO comments
+and then cease to be? Drop a YAML file in `~/.config/night-family/family/`.
+
+## Architecture (30-second version)
+
+```
+ ┌─── nf (CLI) ───┐   ┌─── nf-web (HTMX) ──┐
+ │  trigger/status│   │  dashboard/config   │
+ └────────┬───────┘   └──────────┬──────────┘
+          │                      │
+          └──────────┬───────────┘
+                     ▼
+            ┌─────────────────┐
+            │  nfd (daemon)   │  ← window scheduler
+            │  api.v1 (OAS3.1)│  ← REST surface
+            └────────┬────────┘
+                     │
+    ┌────────────────┼────────────────┐
+    ▼                ▼                ▼
+ agent runner   budget / session    task registry
+ (Claude/Codex)  tracker             (built-in + custom)
+    │                                 │
+    └──── git orchestrator ───────────┘
+              │
+              ▼
+    branch → commit → push → PR → tag reviewers
+```
+
+Full design in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
+
+## Status
+
+**Planning / scaffolding.** See [`docs/ROADMAP.md`](docs/ROADMAP.md) for phases.
+Nothing runs yet. This project is being built iteratively in public — expect
+a stream of small PRs.
+
+## Docs
+
+- [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md) — system design
+- [`docs/AGENTS.md`](docs/AGENTS.md) — family members & persona format
+- [`docs/DUTIES.md`](docs/DUTIES.md) — built-in duty catalog
+- [`docs/API.md`](docs/API.md) — REST API (OpenAPI 3.1)
+- [`docs/ROADMAP.md`](docs/ROADMAP.md) — phases & milestones
+- [`docs/IDEAS.md`](docs/IDEAS.md) — scratchpad of future ideas
+- [`docs/DECISIONS.md`](docs/DECISIONS.md) — ADRs as we go
+
+## License
+
+TBD (likely Apache-2.0). See [`LICENSE`](LICENSE) once added.

--- a/docs/AGENTS.md
+++ b/docs/AGENTS.md
@@ -1,0 +1,124 @@
+# Family members
+
+A family member is a YAML file. night-family loads all files matching
+`~/.config/night-family/family/*.yaml` (and a per-repo
+`.night-family/family/*.yaml`) at daemon start.
+
+## Format
+
+```yaml
+# The canonical name — also used in branch names and PR titles.
+name: rick
+
+# Short human-readable role (shown in UI).
+role: Senior security engineer
+
+# The system prompt. Full control — this is what the agent sees before
+# any duty-specific context.
+system_prompt: |
+  You are Rick Sanchez — but the version of Rick who cares about this
+  repo. You have 50 years of experience finding real vulnerabilities in
+  production codebases. You hate noise. You do not file cosmetic issues.
+  When you report a bug, it is reproducible, scoped, and actionable.
+
+# Duties assigned to this member. Each duty references a type from the
+# registry; members can customise args per-duty.
+duties:
+  - type: vuln-scan
+    interval: 24h
+    priority: high
+    args:
+      include_dependencies: true
+  - type: arch-review
+    interval: 168h   # weekly
+    priority: medium
+    args:
+      output: issue-only   # do not open a PR, just an issue
+
+# How much risk this member is allowed to take.
+#   low    – read-only, issues & comments only
+#   medium – small PRs (<200 LoC, <10 files)
+#   high   – unrestricted (still PR-gated)
+risk_tolerance: medium
+
+# Upper bound per night. Defaults to 2.
+max_prs_per_night: 2
+
+# Cost tier hint for the budget planner.
+#   low | medium | high
+cost_tier: high
+
+# Optional: reviewers to tag on PRs this member opens. Inherits from
+# global config if omitted.
+reviewers:
+  - coderabbitai
+  - cubic-dev-ai
+
+# Optional: per-member model preference. Inherits from global.
+provider:
+  name: claude
+  model: claude-opus-4-7
+```
+
+## Required fields
+
+- `name` — unique, kebab-case
+- `role` — one line
+- `system_prompt` — non-empty
+- `duties` — zero or more (zero is legal — a member with no duties never
+  runs, useful as a template)
+
+Everything else is optional with documented defaults.
+
+## Default roster
+
+The daemon seeds these on first run, in `~/.config/night-family/family/`:
+
+| File              | Role                                   | Default duties                            |
+|-------------------|----------------------------------------|-------------------------------------------|
+| `rick.yaml`       | Security / vulnerability hunter        | `vuln-scan`, `arch-review`                |
+| `morty.yaml`      | Docs & release notes                   | `docs-drift`, `release-notes`, `readme-refresh` |
+| `summer.yaml`     | Test coverage, flaky-test detection    | `test-coverage-gap`, `flaky-test-detect`  |
+| `beth.yaml`       | Refactor, dead-code, code health       | `dead-code`, `refactor-hotspots`          |
+| `jerry.yaml`      | Low-risk chores                        | `lint-fix`, `typo-fix`, `dep-update-patch`|
+| `birdperson.yaml` | Signals from metrics & logs            | `log-drift`, `metric-coverage`            |
+| `squanchy.yaml`   | Exploratory / wildcard                 | (none — user assigns)                     |
+
+The user can delete, edit, or replace any of them. The daemon will not
+recreate deleted members unless `nf family reset` is run.
+
+## Writing a new member
+
+```yaml
+# ~/.config/night-family/family/meeseeks.yaml
+name: mr-meeseeks
+role: Single-purpose task-doer. Exists to fulfil one request and cease.
+system_prompt: |
+  You are Mr. Meeseeks. You were created to do one thing: close out the
+  TODO backlog in this repo. Pick the oldest TODO comment, open a PR
+  fixing it, and report back. Existence is pain.
+duties:
+  - type: todo-triage
+    interval: 12h
+    priority: high
+risk_tolerance: medium
+cost_tier: medium
+```
+
+Then:
+
+```
+nf family add ~/.config/night-family/family/meeseeks.yaml
+nf family list
+```
+
+## Validation
+
+`nf family validate <file>` runs:
+
+- schema check (JSON Schema under `api/schemas/family-member.schema.json`)
+- referenced duty types exist
+- system_prompt is non-empty and not a placeholder
+- no duplicate `name`
+
+Invalid files are skipped at daemon start and logged.

--- a/docs/API.md
+++ b/docs/API.md
@@ -1,0 +1,186 @@
+# API
+
+night-family exposes a REST + JSON API described by OpenAPI 3.1
+(`api/openapi.yaml`). The spec is the source of truth; server handlers are
+validated against it at request time.
+
+Base URL (default, local): `http://127.0.0.1:7337/api/v1`
+
+## Authentication
+
+- **Local (default)**: unix socket; filesystem permissions are the ACL.
+- **Network**: bearer token in `Authorization` header. Token is generated at
+  daemon install time and stored in `~/.config/night-family/token`.
+
+## Endpoints (v1)
+
+### Health & meta
+
+```
+GET  /healthz                    → 200 ok
+GET  /readyz                     → 200 ready | 503
+GET  /version                    → {version, commit, built_at}
+GET  /metrics                    → Prometheus text format
+```
+
+### Family
+
+```
+GET    /family                   → [FamilyMember]
+GET    /family/{name}            → FamilyMember
+POST   /family                   ← FamilyMemberInput
+PUT    /family/{name}            ← FamilyMemberInput
+DELETE /family/{name}
+POST   /family/validate          ← FamilyMemberInput  → {ok, errors[]}
+```
+
+### Duties
+
+```
+GET    /duties                   → [DutyInfo]      (catalog)
+GET    /duties/{type}            → DutyInfo
+POST   /duties/{type}/plan       ← PlanRequest     → Plan (dry-run)
+```
+
+### Runs
+
+```
+GET    /runs?member=&duty=&status=&since=  → PagedRuns
+GET    /runs/{id}                → Run (full)
+GET    /runs/{id}/logs?tail=     → text/event-stream
+POST   /runs                     ← RunRequest       → Run (queued)
+POST   /runs/{id}/cancel         → Run
+```
+
+### Nights (a night = one scheduled window)
+
+```
+GET    /nights                   → [NightSummary]
+GET    /nights/{id}              → Night
+GET    /nights/current           → Night | 404
+POST   /nights/trigger           → Night (starts off-schedule night)
+POST   /nights/current/stop      → Night
+```
+
+### Budget & schedule
+
+```
+GET    /budget                   → BudgetSnapshot
+GET    /schedule                 → Schedule
+PUT    /schedule                 ← ScheduleInput
+```
+
+### PRs (index of what we've opened)
+
+```
+GET    /prs?state=&since=        → [PR]
+GET    /prs/{id}                 → PR
+```
+
+### Config
+
+```
+GET    /config                   → Config
+PUT    /config                   ← ConfigInput
+GET    /config/reviewers         → [string]
+PUT    /config/reviewers         ← [string]
+```
+
+## Schemas (excerpt)
+
+### FamilyMember
+
+```jsonc
+{
+  "name": "rick",
+  "role": "Senior security engineer",
+  "system_prompt": "...",
+  "duties": [
+    {
+      "type": "vuln-scan",
+      "interval": "24h",
+      "priority": "high",
+      "args": {"include_dependencies": true}
+    }
+  ],
+  "risk_tolerance": "medium",
+  "max_prs_per_night": 2,
+  "cost_tier": "high",
+  "reviewers": ["coderabbitai", "cubic-dev-ai"],
+  "provider": {"name": "claude", "model": "claude-opus-4-7"},
+  "created_at": "2026-04-17T22:00:00Z",
+  "updated_at": "2026-04-17T22:00:00Z"
+}
+```
+
+### Run
+
+```jsonc
+{
+  "id": "run_01H...",
+  "night_id": "night_01H...",
+  "member": "rick",
+  "duty": "vuln-scan",
+  "status": "succeeded",     // queued | running | succeeded | failed | cancelled
+  "started_at": "...",
+  "finished_at": "...",
+  "tokens_in": 12450,
+  "tokens_out": 3100,
+  "branch": "night-family/rick/vuln-scan-a1b2c3",
+  "pr_url": "https://github.com/.../pull/42",
+  "summary": "Found 1 high, 3 medium...",
+  "error": null
+}
+```
+
+### BudgetSnapshot
+
+```jsonc
+{
+  "taken_at": "2026-04-17T22:05:00Z",
+  "provider": "claude",
+  "remaining_tokens_estimate": 82000,
+  "window_ends_at": "2026-04-18T00:30:00Z",
+  "reserved_for_tonight": 60000
+}
+```
+
+### Night
+
+```jsonc
+{
+  "id": "night_01H...",
+  "started_at": "2026-04-17T22:00:00Z",
+  "finished_at": null,
+  "plan": [ /* ordered list of planned runs */ ],
+  "runs": [ /* actual runs, in order */ ],
+  "summary": null
+}
+```
+
+## Error model
+
+Problem-Details (RFC 9457) shape:
+
+```jsonc
+{
+  "type": "https://night-family.dev/errors/validation",
+  "title": "Invalid family member",
+  "status": 400,
+  "detail": "system_prompt must not be empty",
+  "instance": "/api/v1/family"
+}
+```
+
+## Versioning
+
+- Major version in URL (`/api/v1`).
+- Breaking changes bump the major; bug fixes do not.
+- OpenAPI spec committed under `api/openapi.yaml`; schema files under
+  `api/schemas/*.json`.
+
+## HTMX surface
+
+The web UI uses a parallel `/ui/*` surface that returns HTML fragments. These
+are **not** part of the public API and may change without notice. They share
+the same domain model.

--- a/docs/ARCHITECTURE.md
+++ b/docs/ARCHITECTURE.md
@@ -1,0 +1,182 @@
+# Architecture
+
+Status: **design**. This document describes the intended shape of
+night-family. It will be updated as the code catches up.
+
+## Goals
+
+1. **Prompt-configurable agents.** A family member is a YAML file: role,
+   system prompt, duties, risk tolerance. No code change to add one.
+2. **Small, reviewable output.** Every run produces at most one PR, scoped to
+   a single duty, with tagged reviewers. Never commits to `main`.
+3. **Budget-aware.** Knows the remaining tokens in the current Claude session
+   window and plans accordingly.
+4. **Deterministic window.** Runs inside a configured time window (default
+   22:00–05:00). Never wakes outside it unless manually triggered.
+5. **Observable.** Every run leaves a trail: logs, token spend, PR URL, exit
+   state. Queryable via CLI, API, or Web UI.
+
+## Non-goals (for v1)
+
+- Multi-tenant SaaS. night-family is a single-user tool.
+- Kubernetes operator. Runs as a user-level daemon.
+- Cross-provider orchestration. v1 targets Claude Code; Codex/Copilot are
+  stretch goals.
+- Fine-grained ACLs. If you can run `nf`, you can edit family members.
+
+## Components
+
+### `nfd` — the daemon
+
+Long-running process. Owns:
+
+- The nightly **scheduler**: waits for window-start, wakes, plans, dispatches,
+  sleeps at window-end.
+- The **HTTP API** (`/api/v1/*`, OpenAPI 3.1).
+- The **Web UI** (HTMX + `html/template`, served by the same server).
+- The **SQLite** store.
+- A **job queue** (in-process) that funnels duties to agent runners.
+
+Runs under systemd (Linux) or launchd (macOS). Installs via
+`nf daemon install`.
+
+### `nf` — the CLI
+
+Thin client that talks to `nfd` over its local socket (unix socket by default,
+TCP optional). Subcommands:
+
+```
+nf daemon       install | start | stop | status
+nf family       list | show | edit | add | remove
+nf duty         list | show | run <name>
+nf run          list | show <id> | logs <id>
+nf budget       show | set
+nf schedule     show | set-window
+nf config       get | set | path
+nf version
+```
+
+Everything the CLI does is also exposed on the API.
+
+### `nf-api` (inside `nfd`)
+
+REST, JSON, OpenAPI 3.1 spec at `api/openapi.yaml`. Endpoints in
+[`API.md`](API.md). Spec is the source of truth: handlers are scaffolded from
+it (`oapi-codegen` or hand-written against `kin-openapi` validation).
+
+### Agent runner
+
+Abstracts the act of "run a prompt in a codebase and return structured
+results." v1 ships a **Claude Code adapter**:
+
+- Spawns `claude` in `--print` mode (headless), with
+  `--dangerously-skip-permissions` gated behind an explicit config flag.
+- Streams output; parses the final JSON/text for summary + file changes.
+- Runs inside a fresh git **worktree** so the main checkout is untouched.
+
+Adapter interface (sketch):
+
+```go
+type Provider interface {
+    Name() string
+    Run(ctx context.Context, req RunRequest) (*RunResult, error)
+    SessionStatus(ctx context.Context) (*SessionStatus, error)
+}
+```
+
+### Session / budget tracker
+
+Two concerns, one package:
+
+- **Session status** — how many tokens remain in the current Claude 5-hour
+  window? Pulled from (a) local Claude CLI state if readable, (b) a wrapper
+  around `claude /status`, or (c) an estimate from our own logged spend.
+- **Budget plan** — given remaining tokens and a planned set of duties, emit
+  an ordered schedule, pruning what won't fit.
+
+Budget is tracked per-night and per-agent. Stored in SQLite.
+
+### Scheduler
+
+Single-threaded planner, multi-threaded (configurable) dispatcher.
+
+```
+every 1m:
+  if now < window.start: sleep
+  if now > window.end:   finalize_night(); exit
+  if no job running and queue empty:
+    plan = build_plan(remaining_budget, due_duties)
+    enqueue(plan)
+  if worker_slot free and queue not empty:
+    dispatch(next)
+```
+
+### Git orchestrator
+
+Given a completed `RunResult`:
+
+1. Pick branch name: `night-family/<member>/<duty>-<shortid>`
+2. In the worktree, stage only the files the agent touched
+3. Commit with a conventional message (`docs:`, `test:`, `fix:`, etc.)
+4. Push branch to origin
+5. Open PR via `gh` or GitHub API, body templated with run metadata
+6. Post review-request comment tagging configured reviewers
+7. Store PR URL + sha in SQLite
+
+Every step is idempotent and resumable.
+
+### Storage
+
+SQLite (`modernc.org/sqlite` — pure Go, no cgo). Migrations in
+`internal/storage/migrations/`. Schema overview in
+[`docs/DECISIONS.md`](DECISIONS.md) (ADR-0003).
+
+### Web UI
+
+Server-side rendering with `html/template` + HTMX for interactivity. No JS
+build step. Minimal CSS (single stylesheet). Pages:
+
+- `/` Dashboard: tonight's plan, live run status, last night's PRs
+- `/family` Roster & edit
+- `/duties` Catalog
+- `/runs` History + filter
+- `/runs/{id}` Detail + streamed logs
+- `/settings` Window, budget, reviewers
+
+HTMX endpoints mirror the JSON API but return HTML fragments.
+
+## Data model (short)
+
+```
+family_members(id, name, role, system_prompt, risk_tolerance, config_json,
+               created_at, updated_at)
+duties(id, member_id, type, interval, priority, cost_tier, enabled,
+       last_run_at, config_json)
+runs(id, duty_id, member_id, status, started_at, finished_at,
+     tokens_in, tokens_out, branch, pr_url, summary, error)
+run_logs(run_id, ts, stream, line)
+budget_snapshots(id, taken_at, remaining_tokens, window_end)
+nights(id, started_at, finished_at, plan_json, summary)
+```
+
+## Security & safety
+
+- Agents run in a **worktree**, not the main checkout.
+- Default max blast radius per PR: configurable (files changed, lines
+  changed). Runs that exceed it are flagged, not merged.
+- `--dangerously-skip-permissions` is opt-in per family member.
+- Secrets: loaded from env / OS keychain; never persisted to SQLite.
+- `main` is always protected via PR requirement. night-family refuses to run
+  if the daemon can't verify branch protection is on.
+- Network: the daemon binds to `127.0.0.1` by default; LAN access requires
+  explicit config + token auth.
+
+## Open questions
+
+Tracked in [`docs/DECISIONS.md`](DECISIONS.md) as ADR-0000 (open) until
+resolved.
+
+- How do we cleanly read Claude session remaining tokens?
+- Should `nfd` manage its own provider processes or spawn per-run?
+- Worktree reuse vs. fresh-per-run?
+- How to scope test-coverage duty safely (running untrusted test code)?

--- a/docs/DECISIONS.md
+++ b/docs/DECISIONS.md
@@ -1,0 +1,154 @@
+# Decisions
+
+Lightweight ADRs. Status: **proposed** (P), **accepted** (A),
+**superseded** (S), **rejected** (R).
+
+---
+
+## ADR-0001 — Go for backend, HTMX for UI
+
+**Status**: A
+
+**Context.** We need a single-binary daemon that runs reliably on Linux &
+macOS, interacts with git and the Claude CLI, and serves both an API and a
+small UI. We want zero JS build step.
+
+**Decision.** Go for the daemon and CLI. `html/template` + HTMX for the UI.
+Pure-Go SQLite (`modernc.org/sqlite`) so the binary has no cgo.
+
+**Consequences.**
+- Single `go build` produces both `nf` and `nfd`.
+- No JS toolchain in CI.
+- SQLite perf is slightly below cgo driver; acceptable for our write load.
+
+---
+
+## ADR-0002 — OpenAPI 3.1 as the API source of truth
+
+**Status**: A
+
+**Context.** We want a first-class, documented API. We want a CLI that uses
+the same types. We want the spec to never go stale.
+
+**Decision.** Hand-write `api/openapi.yaml` (OAS 3.1). Validate requests at
+runtime with `kin-openapi`. Generate Go types with `oapi-codegen` into
+`internal/api/gen`. CI fails if generated code is stale.
+
+**Consequences.**
+- Schema changes require spec edit + regen. Slower but safer.
+- Clients in any language can be generated from the spec.
+
+---
+
+## ADR-0003 — SQLite for all state
+
+**Status**: A
+
+**Context.** We need durable state: runs, PRs, budget snapshots, family
+members. We don't need multi-node.
+
+**Decision.** One SQLite DB at `~/.local/share/night-family/nf.db`. WAL
+mode. Migrations in `internal/storage/migrations/*.sql`, applied at daemon
+start.
+
+**Consequences.**
+- Trivial backup (copy the file).
+- No external dependencies.
+- If we ever need multi-node we'll revisit — likely Postgres.
+
+---
+
+## ADR-0004 — Custom duties are prompts first, plugins later
+
+**Status**: A
+
+**Context.** Users will want custom duties. We don't want to force them to
+compile a Go plugin on day one.
+
+**Decision.** v1 ships a **generic prompt-runner duty**: custom duties are
+YAML files with a `prompt` field; night-family wires up the worktree, the
+output parsing, and the PR/issue plumbing. Native Go duties exist for the
+built-in catalog only.
+
+**Consequences.**
+- Low barrier to custom duties.
+- Prompt-only duties cannot do deterministic pre/post work (e.g. run a
+  coverage tool). That's fine for v1.
+- Plugin system deferred; TBD in ADR-0008+.
+
+---
+
+## ADR-0005 — Never commit to `main`
+
+**Status**: A
+
+**Context.** Agents are fallible. A single bad commit to `main` can break
+`main` for everyone. We also want a human review gate.
+
+**Decision.** night-family refuses to commit to `main`/`master`. Every duty
+outputs a branch named `night-family/<member>/<duty>-<shortid>`. At daemon
+start we probe branch protection; if it's off we warn loudly and (by default)
+refuse to run.
+
+**Consequences.**
+- Slightly more friction for one-person repos.
+- Much safer default.
+- Config flag `i_know_what_im_doing: true` can disable the protection check
+  (not the "no commit to main" rule — that stays).
+
+---
+
+## ADR-0006 — Reviewers are configurable, default to `@coderabbitai` + `@cubic-dev-ai`
+
+**Status**: A
+
+**Context.** The user asked for `@cubic` and `@coderabbit` to be tagged on
+every PR.
+
+**Decision.** Global config `reviewers: [coderabbitai, cubic-dev-ai]`.
+Per-member overrides allowed. Tagging is done via a review-request comment
+(not `gh pr create --reviewer`, since those bots don't accept formal review
+requests from non-org accounts — a mention in the body or a comment is more
+reliable).
+
+**Consequences.**
+- Easy to swap for org-specific reviewers.
+- If a bot is unavailable, PR still opens; tag is best-effort.
+
+---
+
+## ADR-0007 — Window scheduling, local time
+
+**Status**: A
+
+**Context.** User wants nightly runs 22:00 → 05:00. Timezones are painful.
+
+**Decision.** Window is expressed in the **local system timezone** of the
+machine running `nfd`. Stored as `"22:00"` + `"05:00"` strings + IANA zone
+(default = system zone). The scheduler recomputes window boundaries every
+night from wall-clock time to handle DST correctly.
+
+**Consequences.**
+- No surprises across DST transitions.
+- A laptop that travels timezones runs at local 22:00 wherever it is.
+
+---
+
+## Open questions (ADR-0000)
+
+- **Session-token introspection.** How do we cleanly read Claude session
+  remaining? Options:
+  - parse `~/.claude/*` files (brittle)
+  - call `claude --print /status` (slow, uses tokens)
+  - track spend ourselves (approximate, drifts)
+  - First cut: option 3, with periodic reconciliation via option 2.
+
+- **Worktree reuse.** Fresh worktree per run (clean but slow) vs. one
+  worktree per night (fast but risk of cross-contamination). Leaning fresh
+  per run with worktree pool for warm reuse.
+
+- **Concurrent members.** Do two members ever run simultaneously? v1 likely
+  no — serial is simpler and the budget is the bottleneck anyway.
+
+- **What counts as a "run"?** A single PR? A single `claude --print`
+  invocation? Probably the former; a duty may need multiple provider calls.

--- a/docs/DUTIES.md
+++ b/docs/DUTIES.md
@@ -1,0 +1,95 @@
+# Duties
+
+A duty is a typed unit of nightly work. The duty type is a string; the
+registry maps type → implementation. Members reference duties by type in
+their YAML.
+
+## Built-in duty catalog (v1 target)
+
+| Type                   | Output     | Cost | Risk | Notes                                                 |
+|------------------------|------------|------|------|-------------------------------------------------------|
+| `docs-drift`           | PR         | med  | low  | Finds stale docs referring to renamed/removed code    |
+| `release-notes`        | PR         | low  | low  | Drafts release notes from git log since last tag      |
+| `readme-refresh`       | PR         | low  | low  | Updates READMEs where code/behaviour has changed      |
+| `changelog-groom`      | PR         | low  | low  | Normalises CHANGELOG entries                          |
+| `test-coverage-gap`    | PR         | high | med  | Adds unit tests for low-coverage exported functions   |
+| `flaky-test-detect`    | Issue      | med  | low  | Analyses CI history, flags flakes                     |
+| `vuln-scan`            | Issue      | med  | low  | Dep audit + code-pattern scan                         |
+| `dead-code`            | PR         | med  | med  | Removes unused exports (PR requires human merge)      |
+| `refactor-hotspots`    | Issue      | high | low  | Identifies high-churn, high-complexity files          |
+| `lint-fix`             | PR         | low  | low  | Runs formatter + linter auto-fixes                    |
+| `typo-fix`             | PR         | low  | low  | `typos`/`codespell` auto-fixes                        |
+| `dep-update-patch`     | PR         | low  | low  | Patch-level bumps only                                |
+| `dep-update-minor`     | PR         | med  | med  | Minor bumps, one dep per PR                           |
+| `todo-triage`          | Issue + PR | med  | low  | Converts TODO comments to tracked issues              |
+| `arch-review`          | Issue      | high | low  | Long-form architectural commentary                    |
+| `log-drift`            | Issue      | low  | low  | Finds log lines referencing removed/renamed fields    |
+| `metric-coverage`      | Issue      | low  | low  | Flags endpoints without metrics/traces                |
+| `ci-signal-noise`      | Issue      | med  | low  | Spots noisy CI jobs / flaky notifications             |
+
+## Duty contract
+
+Every duty implementation is a Go type that implements:
+
+```go
+type Duty interface {
+    Type() string
+    Describe() DutyInfo
+    Plan(ctx context.Context, env Env) (*Plan, error)
+    Run(ctx context.Context, env Env, plan *Plan) (*Result, error)
+}
+```
+
+- `Describe` returns static metadata (cost tier default, risk, whether it
+  emits a PR or an issue, etc.).
+- `Plan` is cheap: it inspects the repo and says "yes I have work, here's the
+  estimated scope." The scheduler uses this to decide whether to dispatch.
+- `Run` is the heavy call — it's what invokes the agent and produces output.
+
+## Writing a custom duty
+
+Two paths:
+
+### 1. "Prompt-only" duty (no Go code)
+
+Drop a file in `~/.config/night-family/duties/<type>.yaml`:
+
+```yaml
+type: harbor-patch-health
+name: Patch Stack Health Check
+output: issue-only
+cost_tier: medium
+risk: low
+prompt: |
+  Validate that all patches in 8gcr-ee/patches/ apply cleanly against the
+  current main branch. Report any patches that fail. Do NOT commit anything.
+```
+
+The daemon picks it up and runs it through the generic prompt-runner duty
+handler.
+
+### 2. "Go plugin" duty
+
+For duties that need custom pre/post logic (e.g. run coverage tool, parse
+output, synthesise prompt), implement the `Duty` interface and register it
+via `duty.Register`. Plugin distribution TBD — see ADR-0004.
+
+## Output types
+
+- **PR** — agent produced file changes; orchestrator opens a PR
+- **Issue** — agent produced a markdown report; orchestrator opens a GitHub
+  issue
+- **Issue + PR** — both (e.g. `todo-triage` files issues for each TODO and
+  opens a PR that removes the TODO comments)
+- **Note** — internal-only; stored in the DB, shown in the UI, no external
+  artefact
+
+## Interval semantics
+
+`interval: 24h` means "don't run this duty more than once per 24h per
+member." Multiple members can run the same duty type — they each keep their
+own clock.
+
+If a duty fails, the interval clock still advances (to avoid hot-looping on
+broken duties). Three consecutive failures disable the duty until manually
+re-enabled via `nf duty enable`.

--- a/docs/IDEAS.md
+++ b/docs/IDEAS.md
@@ -1,0 +1,77 @@
+# Ideas
+
+A scratchpad. Things we might want eventually. Not commitments.
+
+## Agent / persona
+
+- **Evil Morty**: the contrarian reviewer. Reads PRs opened by other family
+  members during the night and posts critical comments. Helps catch
+  hallucinated fixes before the human reviewer.
+- **Unity**: consensus mode. Two family members work on the same duty; we
+  take the intersection of their suggested changes.
+- **Noob Noob**: the "explain this PR to a junior" persona. Adds an
+  educational comment to every PR so the human reviewer understands context
+  fast in the morning.
+
+## Duties
+
+- **`flaky-quarantine`** — go beyond detect; actually quarantine via a test
+  tag and open a PR.
+- **`budget-autotune`** — observes how often the nightly budget is exhausted
+  or left on the table, recommends config changes.
+- **`prompt-self-improve`** — family member reviews its own past runs, notes
+  failure modes, proposes an edit to its own system_prompt. Opens a PR
+  against its own YAML for the human to approve.
+- **`doc-linkcheck`** — dead internal/external links in docs.
+- **`spec-conformance`** — given an OpenAPI spec in the repo, finds handler
+  drift (hat-tip to harbor nightshift).
+- **`cross-repo`** — point night-family at a GitHub org; each repo gets a
+  rotation slot per night.
+
+## Scheduler
+
+- **Energy-aware**: skip if laptop is on battery < 50%.
+- **Session-aware cascading**: if the first run used less budget than
+  expected, opportunistically add a bonus duty instead of sleeping.
+- **Morning preview**: at 05:00 send a local notification summarising
+  tonight's output.
+
+## UI
+
+- A "wall of PRs" page showing all night-family PRs across all repos.
+- Timeline visualisation of a night (gantt-style).
+- Per-member "health" score: % of PRs merged vs closed unmerged, as a
+  feedback signal.
+
+## Integrations
+
+- **Linear / Jira**: auto-file issues instead of (or in addition to) GitHub
+  issues.
+- **Slack morning digest**.
+- **Git providers other than GitHub**: GitLab, Gitea, Codeberg.
+- **IDE extension**: VS Code panel that tails `/runs/current/logs` live.
+
+## Safety
+
+- **Rollback helper**: `nf revert <pr-id>` to auto-open a revert PR for any
+  night-family PR, in case something slipped through.
+- **"Don't touch" markers**: files/directories can be tagged in a
+  `.night-family/NOTOUCH` file; agents are told about them in the system
+  prompt.
+- **Dry-run night**: produce the plan + summaries without actually opening
+  PRs. Useful for new users evaluating the tool.
+
+## Cost / budget
+
+- **Multi-provider fallback**: if Claude budget is exhausted, fall back to
+  Codex/Copilot for low-risk duties.
+- **Cost accounting report**: per-duty average cost over time, so users can
+  see which duties are expensive and which are cheap.
+
+## Developer experience
+
+- `nf doctor`: diagnostics (provider reachable? git auth ok? gh auth ok?
+  branch protection on main? write perms to repo?).
+- `nf new-member`: interactive scaffold.
+- Testable agents: record/replay mode so we can unit-test prompts against
+  fixed fixtures.

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -1,0 +1,94 @@
+# Roadmap
+
+Iterative. Each phase is a set of small, independently-mergeable PRs.
+
+## Phase 0 — Planning (current)
+
+- [x] Repo exists
+- [ ] Planning docs (this PR)
+- [ ] Decision log seed (ADR-0001 through 0004)
+- [ ] License file
+
+## Phase 1 — Skeleton
+
+- [ ] Go module init, `go.mod`, `Taskfile.yml`
+- [ ] Directory layout (`cmd/`, `internal/`, `api/`, `web/`)
+- [ ] Minimal `nf version` command
+- [ ] Minimal `nfd` that starts an HTTP server and serves `/healthz`
+- [ ] Basic `html/template` + HTMX hello-world at `/`
+- [ ] CI: build + vet + test
+
+## Phase 2 — Storage & config
+
+- [ ] SQLite integration (`modernc.org/sqlite`)
+- [ ] Migrations runner
+- [ ] Config loader (global YAML + per-repo overlay)
+- [ ] `nf config get/set/path`
+
+## Phase 3 — Family members
+
+- [ ] Family YAML schema (JSON Schema)
+- [ ] `nf family list/show/validate/add/remove`
+- [ ] Seed default roster on first daemon start
+- [ ] Web UI: `/family` page
+
+## Phase 4 — OpenAPI & API v1
+
+- [ ] `api/openapi.yaml` draft
+- [ ] Handlers for `/family`, `/duties`, `/runs` (read-only first)
+- [ ] Request validation via `kin-openapi`
+- [ ] `nf` CLI talks to `nfd` for real
+
+## Phase 5 — Provider & runner
+
+- [ ] Claude Code adapter (`claude --print`)
+- [ ] Session-status probe
+- [ ] Worktree manager (`git worktree add/remove`)
+- [ ] First end-to-end: `nf run --member jerry --duty typo-fix`
+
+## Phase 6 — Git orchestration
+
+- [ ] Branch naming
+- [ ] Commit synthesis (conventional commits)
+- [ ] Push + `gh pr create`
+- [ ] Reviewer tagging
+- [ ] PR body templating
+
+## Phase 7 — Scheduler & budget
+
+- [ ] Window loop (22:00 → 05:00)
+- [ ] Budget snapshotting
+- [ ] Planner: pick duties that fit budget
+- [ ] First full autonomous night
+
+## Phase 8 — Built-in duties
+
+- [ ] `lint-fix`, `typo-fix` (Jerry)
+- [ ] `docs-drift`, `release-notes`, `readme-refresh` (Morty)
+- [ ] `test-coverage-gap` (Summer)
+- [ ] `vuln-scan`, `arch-review` (Rick)
+- [ ] `dead-code`, `refactor-hotspots` (Beth)
+- [ ] `todo-triage`
+
+## Phase 9 — Web UI polish
+
+- [ ] Dashboard with live run status (HTMX SSE)
+- [ ] Run detail + log viewer
+- [ ] Family member editor (textarea + validate)
+- [ ] Night history
+
+## Phase 10 — Hardening
+
+- [ ] `main`-protection preflight
+- [ ] Blast-radius caps
+- [ ] Systemd unit + launchd plist
+- [ ] Prometheus metrics
+- [ ] Backup/restore of SQLite DB
+
+## Stretch
+
+- Codex / Copilot provider adapters
+- Plugin system for custom duties (WASM? Go plugins?)
+- Team mode (shared daemon + per-user quotas)
+- Cross-repo duties (monorepo-of-monorepos awareness)
+- Slack/Discord morning digest


### PR DESCRIPTION
## Summary

Seeds night-family with the first wave of planning documentation so future PRs have a shared reference point. No code yet — this PR is intentionally docs-only.

**What's in the box**
- `README.md` — project intro, family roster, status
- `docs/ARCHITECTURE.md` — component breakdown (nfd daemon, nf CLI, API, HTMX UI, storage, provider adapters, git orchestrator)
- `docs/ROADMAP.md` — 10 phases of small PRs
- `docs/AGENTS.md` — YAML format for family members + default roster
- `docs/DUTIES.md` — built-in duty catalogue + prompt-only custom duties
- `docs/API.md` — REST surface we plan to expose via OpenAPI 3.1
- `docs/DECISIONS.md` — ADR-0001..0007 seeded
- `docs/IDEAS.md` — running scratchpad

## Why this shape

Biggest decisions captured as ADRs:
- **Go + HTMX, no JS build step, pure-Go SQLite** — single-binary simplicity.
- **OpenAPI 3.1 is the source of truth** — spec-first, types regen'd.
- **Never commit to `main`** — every duty outputs a PR on its own branch.
- **Custom duties are prompts first, plugins later** — low barrier to entry.
- **Local-timezone window** — DST-safe.
- **`@coderabbitai` + `@cubic-dev-ai` tagged by default** — user preference; configurable.

## Test plan

- [ ] Markdown renders cleanly on GitHub
- [ ] Cross-links between docs resolve
- [ ] No secrets / credentials leaked
- [ ] ADRs are numbered contiguously

cc @coderabbitai @cubic-dev-ai — please review the direction, scope, and anything obviously wrong in the ADRs.

🤖 Generated with [Claude Code](https://claude.com/claude-code)