### PR TITLE
feat(duty): built-in catalogue with API + CLI

### DIFF
--- a/cmd/nf/duty.go
+++ b/cmd/nf/duty.go
@@ -1,0 +1,84 @@
+package main
+
+import (
+	"encoding/json"
+	"flag"
+	"fmt"
+	"os"
+	"text/tabwriter"
+)
+
+const dutyUsage = `nf duty — inspect the duty catalogue
+
+Usage:
+  nf duty list              List known duty types
+  nf duty show <type>       Show metadata for one duty type
+`
+
+type dutyInfo struct {
+	Type        string `json:"type"`
+	Description string `json:"description"`
+	Output      string `json:"output"`
+	CostTier    string `json:"cost_tier"`
+	Risk        string `json:"risk"`
+	Builtin     bool   `json:"builtin"`
+}
+
+func dutyCmd(args []string) {
+	if len(args) == 0 {
+		fmt.Fprint(os.Stderr, dutyUsage)
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "list":
+		dutyList(args[1:])
+	case "show":
+		dutyShow(args[1:])
+	case "help", "-h", "--help":
+		fmt.Print(dutyUsage)
+	default:
+		fmt.Fprintf(os.Stderr, "nf duty: unknown subcommand %q\n\n", args[0])
+		fmt.Fprint(os.Stderr, dutyUsage)
+		os.Exit(2)
+	}
+}
+
+func dutyList(args []string) {
+	fs := flag.NewFlagSet("duty list", flag.ExitOnError)
+	jsonOut := fs.Bool("json", false, "emit JSON instead of a table")
+	_ = fs.Parse(args)
+
+	var duties []dutyInfo
+	if err := apiGet("/api/v1/duties", &duties); err != nil {
+		fmt.Fprintln(os.Stderr, "nf:", err)
+		os.Exit(1)
+	}
+	if *jsonOut {
+		enc := json.NewEncoder(os.Stdout)
+		enc.SetIndent("", "  ")
+		_ = enc.Encode(duties)
+		return
+	}
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "TYPE\tOUTPUT\tCOST\tRISK\tDESCRIPTION")
+	for _, d := range duties {
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
+			d.Type, d.Output, d.CostTier, d.Risk, d.Description)
+	}
+	_ = tw.Flush()
+}
+
+func dutyShow(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "nf duty show: <type> required")
+		os.Exit(2)
+	}
+	var info map[string]any
+	if err := apiGet("/api/v1/duties/"+args[0], &info); err != nil {
+		fmt.Fprintln(os.Stderr, "nf:", err)
+		os.Exit(1)
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(info)
+}

--- a/cmd/nf/main.go
+++ b/cmd/nf/main.go
@@ -23,6 +23,7 @@ Usage:
 Commands:
   version    Print build metadata
   family     Inspect the family roster (list|show)
+  duty       Inspect the duty catalogue (list|show)
   help       Show this help
 
 Environment:
@@ -41,6 +42,8 @@ func main() {
 		versionCmd(os.Args[2:])
 	case "family":
 		familyCmd(os.Args[2:])
+	case "duty":
+		dutyCmd(os.Args[2:])
 	case "help", "--help", "-h":
 		fmt.Print(usage)
 	default:

--- a/cmd/nfd/main.go
+++ b/cmd/nfd/main.go
@@ -15,6 +15,7 @@ import (
 	"syscall"
 	"time"
 
+	"github.com/bupd/night-family/internal/duty"
 	"github.com/bupd/night-family/internal/family"
 	"github.com/bupd/night-family/internal/server"
 )
@@ -35,10 +36,14 @@ func main() {
 	fam.Seed(defaults)
 	logger.Info("family seeded", "count", fam.Len())
 
+	duties := duty.NewBuiltinRegistry()
+	logger.Info("duties loaded", "count", duties.Len())
+
 	srv, err := server.New(server.Config{
 		Addr:   *addr,
 		Logger: logger,
 		Family: fam,
+		Duties: duties,
 	})
 	if err != nil {
 		fatal(logger, "server init: %v", err)

--- a/internal/duty/duty.go
+++ b/internal/duty/duty.go
@@ -1,0 +1,251 @@
+// Package duty is the central registry of duty types known to
+// night-family. Each entry captures the cheap static metadata a
+// planner needs to reason about cost, risk, and output kind.
+//
+// The actual execution of a duty (prompt synthesis, provider call,
+// output parsing, PR/issue creation) happens in a separate package.
+// This package is side-effect-free — import it from the validator
+// and the API without pulling in a provider dependency.
+package duty
+
+import (
+	"sort"
+	"sync"
+
+	"github.com/bupd/night-family/internal/family"
+)
+
+// Output describes what a duty produces when it runs.
+type Output string
+
+const (
+	OutputPR          Output = "pr"
+	OutputIssue       Output = "issue"
+	OutputIssuePlusPR Output = "issue-plus-pr"
+	OutputNote        Output = "note"
+)
+
+// Info is the static, serialisable metadata for a duty type.
+type Info struct {
+	Type        string      `json:"type"`
+	Description string      `json:"description"`
+	Output      Output      `json:"output"`
+	CostTier    family.Cost `json:"cost_tier"`
+	Risk        family.Risk `json:"risk"`
+	Builtin     bool        `json:"builtin"`
+}
+
+// Registry is a name → Info lookup. Safe for concurrent reads after
+// Register has finished at startup.
+type Registry struct {
+	mu    sync.RWMutex
+	items map[string]Info
+}
+
+// NewRegistry returns an empty Registry.
+func NewRegistry() *Registry {
+	return &Registry{items: make(map[string]Info)}
+}
+
+// Register adds or replaces a duty. Returns the stored Info.
+func (r *Registry) Register(info Info) Info {
+	r.mu.Lock()
+	defer r.mu.Unlock()
+	r.items[info.Type] = info
+	return info
+}
+
+// Get returns the Info for a type, or (zero, false) when unknown.
+func (r *Registry) Get(typ string) (Info, bool) {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	i, ok := r.items[typ]
+	return i, ok
+}
+
+// Has reports whether a duty type is known.
+func (r *Registry) Has(typ string) bool {
+	_, ok := r.Get(typ)
+	return ok
+}
+
+// List returns all duties sorted by Type.
+func (r *Registry) List() []Info {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	out := make([]Info, 0, len(r.items))
+	for _, i := range r.items {
+		out = append(out, i)
+	}
+	sort.SliceStable(out, func(i, j int) bool { return out[i].Type < out[j].Type })
+	return out
+}
+
+// Len returns the number of registered duties.
+func (r *Registry) Len() int {
+	r.mu.RLock()
+	defer r.mu.RUnlock()
+	return len(r.items)
+}
+
+// Builtins returns the canonical v1 duty catalogue. See docs/DUTIES.md
+// for the narrative version. This is the single source of truth for
+// what duty types ship with night-family.
+func Builtins() []Info {
+	return []Info{
+		{
+			Type:        "docs-drift",
+			Description: "Find stale docs referring to renamed/removed code and fix them.",
+			Output:      OutputPR,
+			CostTier:    family.CostMedium,
+			Risk:        family.RiskLow,
+			Builtin:     true,
+		},
+		{
+			Type:        "release-notes",
+			Description: "Draft release notes from git log since the last tag.",
+			Output:      OutputPR,
+			CostTier:    family.CostLow,
+			Risk:        family.RiskLow,
+			Builtin:     true,
+		},
+		{
+			Type:        "readme-refresh",
+			Description: "Update READMEs when code or behaviour has drifted.",
+			Output:      OutputPR,
+			CostTier:    family.CostLow,
+			Risk:        family.RiskLow,
+			Builtin:     true,
+		},
+		{
+			Type:        "changelog-groom",
+			Description: "Normalise CHANGELOG entries for consistency.",
+			Output:      OutputPR,
+			CostTier:    family.CostLow,
+			Risk:        family.RiskLow,
+			Builtin:     true,
+		},
+		{
+			Type:        "test-coverage-gap",
+			Description: "Add unit tests for low-coverage exported functions.",
+			Output:      OutputPR,
+			CostTier:    family.CostHigh,
+			Risk:        family.RiskMedium,
+			Builtin:     true,
+		},
+		{
+			Type:        "flaky-test-detect",
+			Description: "Analyse CI history, flag flaky tests.",
+			Output:      OutputIssue,
+			CostTier:    family.CostMedium,
+			Risk:        family.RiskLow,
+			Builtin:     true,
+		},
+		{
+			Type:        "vuln-scan",
+			Description: "Dependency audit plus code-pattern scan.",
+			Output:      OutputIssue,
+			CostTier:    family.CostMedium,
+			Risk:        family.RiskLow,
+			Builtin:     true,
+		},
+		{
+			Type:        "dead-code",
+			Description: "Remove unused exports (PR requires human merge).",
+			Output:      OutputPR,
+			CostTier:    family.CostMedium,
+			Risk:        family.RiskMedium,
+			Builtin:     true,
+		},
+		{
+			Type:        "refactor-hotspots",
+			Description: "Identify high-churn, high-complexity files.",
+			Output:      OutputIssue,
+			CostTier:    family.CostHigh,
+			Risk:        family.RiskLow,
+			Builtin:     true,
+		},
+		{
+			Type:        "lint-fix",
+			Description: "Run the formatter + linter's auto-fixes.",
+			Output:      OutputPR,
+			CostTier:    family.CostLow,
+			Risk:        family.RiskLow,
+			Builtin:     true,
+		},
+		{
+			Type:        "typo-fix",
+			Description: "Fix typos in comments, docs, and safe identifiers.",
+			Output:      OutputPR,
+			CostTier:    family.CostLow,
+			Risk:        family.RiskLow,
+			Builtin:     true,
+		},
+		{
+			Type:        "dep-update-patch",
+			Description: "Bump patch-level dependencies one at a time.",
+			Output:      OutputPR,
+			CostTier:    family.CostLow,
+			Risk:        family.RiskLow,
+			Builtin:     true,
+		},
+		{
+			Type:        "dep-update-minor",
+			Description: "Bump minor-level dependencies, one per PR.",
+			Output:      OutputPR,
+			CostTier:    family.CostMedium,
+			Risk:        family.RiskMedium,
+			Builtin:     true,
+		},
+		{
+			Type:        "todo-triage",
+			Description: "Convert TODO comments into tracked GitHub issues.",
+			Output:      OutputIssuePlusPR,
+			CostTier:    family.CostMedium,
+			Risk:        family.RiskLow,
+			Builtin:     true,
+		},
+		{
+			Type:        "arch-review",
+			Description: "Long-form architectural commentary filed as an issue.",
+			Output:      OutputIssue,
+			CostTier:    family.CostHigh,
+			Risk:        family.RiskLow,
+			Builtin:     true,
+		},
+		{
+			Type:        "log-drift",
+			Description: "Find log lines referencing removed or renamed fields.",
+			Output:      OutputIssue,
+			CostTier:    family.CostLow,
+			Risk:        family.RiskLow,
+			Builtin:     true,
+		},
+		{
+			Type:        "metric-coverage",
+			Description: "Flag endpoints without metrics or traces.",
+			Output:      OutputIssue,
+			CostTier:    family.CostLow,
+			Risk:        family.RiskLow,
+			Builtin:     true,
+		},
+		{
+			Type:        "ci-signal-noise",
+			Description: "Spot noisy CI jobs or flaky notifications.",
+			Output:      OutputIssue,
+			CostTier:    family.CostMedium,
+			Risk:        family.RiskLow,
+			Builtin:     true,
+		},
+	}
+}
+
+// NewBuiltinRegistry returns a Registry pre-populated with the built-in
+// catalogue.
+func NewBuiltinRegistry() *Registry {
+	r := NewRegistry()
+	for _, d := range Builtins() {
+		r.Register(d)
+	}
+	return r
+}

--- a/internal/duty/duty_test.go
+++ b/internal/duty/duty_test.go
@@ -1,0 +1,81 @@
+package duty
+
+import (
+	"testing"
+
+	"github.com/bupd/night-family/internal/family"
+)
+
+func TestBuiltinsUniqueAndComplete(t *testing.T) {
+	seen := map[string]bool{}
+	for _, d := range Builtins() {
+		if seen[d.Type] {
+			t.Errorf("duplicate built-in type: %s", d.Type)
+		}
+		seen[d.Type] = true
+		if d.Description == "" {
+			t.Errorf("%s: empty description", d.Type)
+		}
+		if !d.Builtin {
+			t.Errorf("%s: Builtin flag not set", d.Type)
+		}
+		switch d.Output {
+		case OutputPR, OutputIssue, OutputIssuePlusPR, OutputNote:
+		default:
+			t.Errorf("%s: invalid Output %q", d.Type, d.Output)
+		}
+		switch d.CostTier {
+		case family.CostLow, family.CostMedium, family.CostHigh:
+		default:
+			t.Errorf("%s: invalid CostTier %q", d.Type, d.CostTier)
+		}
+		switch d.Risk {
+		case family.RiskLow, family.RiskMedium, family.RiskHigh:
+		default:
+			t.Errorf("%s: invalid Risk %q", d.Type, d.Risk)
+		}
+	}
+	// Spot-check: must cover the duty types referenced by the default roster.
+	defaultDutyTypes := []string{
+		"vuln-scan", "arch-review", "docs-drift", "release-notes",
+		"readme-refresh", "changelog-groom", "test-coverage-gap",
+		"flaky-test-detect", "dead-code", "refactor-hotspots",
+		"lint-fix", "typo-fix", "dep-update-patch", "log-drift",
+		"metric-coverage",
+	}
+	for _, want := range defaultDutyTypes {
+		if !seen[want] {
+			t.Errorf("built-in catalogue missing %q (referenced by default roster)", want)
+		}
+	}
+}
+
+func TestRegistryOperations(t *testing.T) {
+	r := NewRegistry()
+	if r.Len() != 0 {
+		t.Fatalf("fresh Registry Len = %d", r.Len())
+	}
+	r.Register(Info{
+		Type: "custom", Description: "x",
+		Output: OutputNote, CostTier: family.CostLow, Risk: family.RiskLow,
+	})
+	if !r.Has("custom") {
+		t.Errorf("Has(custom) false after Register")
+	}
+	if _, ok := r.Get("custom"); !ok {
+		t.Errorf("Get(custom) missing")
+	}
+	if _, ok := r.Get("ghost"); ok {
+		t.Errorf("Get(ghost) found an item")
+	}
+	if r.Len() != 1 {
+		t.Errorf("Len = %d, want 1", r.Len())
+	}
+}
+
+func TestBuiltinRegistryPopulated(t *testing.T) {
+	r := NewBuiltinRegistry()
+	if r.Len() != len(Builtins()) {
+		t.Fatalf("Len = %d, want %d", r.Len(), len(Builtins()))
+	}
+}

--- a/internal/server/duties.go
+++ b/internal/server/duties.go
@@ -1,0 +1,58 @@
+package server
+
+import (
+	"net/http"
+
+	"github.com/bupd/night-family/internal/duty"
+)
+
+func (s *Server) dutiesRoutes(mux *http.ServeMux) {
+	if s.cfg.Duties == nil {
+		return
+	}
+	mux.HandleFunc("GET /api/v1/duties", s.listDuties)
+	mux.HandleFunc("GET /api/v1/duties/{type}", s.getDuty)
+	mux.HandleFunc("GET /duties", s.dutiesPage)
+}
+
+func (s *Server) listDuties(w http.ResponseWriter, _ *http.Request) {
+	writeJSON(w, http.StatusOK, s.cfg.Duties.List())
+}
+
+func (s *Server) getDuty(w http.ResponseWriter, r *http.Request) {
+	typ := r.PathValue("type")
+	info, ok := s.cfg.Duties.Get(typ)
+	if !ok {
+		writeProblem(w, http.StatusNotFound, "not_found", "Duty type not found", r.URL.Path)
+		return
+	}
+	writeJSON(w, http.StatusOK, info)
+}
+
+func (s *Server) dutiesPage(w http.ResponseWriter, _ *http.Request) {
+	all := s.cfg.Duties.List()
+	// Group by Output for the card layout.
+	byOutput := map[duty.Output][]duty.Info{}
+	for _, d := range all {
+		byOutput[d.Output] = append(byOutput[d.Output], d)
+	}
+	data := struct {
+		Title     string
+		Version   string
+		Duties    []duty.Info
+		ByOutput  map[duty.Output][]duty.Info
+		OutputPR  duty.Output
+		OutputIss duty.Output
+		OutputIPR duty.Output
+		OutputNot duty.Output
+	}{
+		Title:     "Duties — night-family",
+		Duties:    all,
+		ByOutput:  byOutput,
+		OutputPR:  duty.OutputPR,
+		OutputIss: duty.OutputIssue,
+		OutputIPR: duty.OutputIssuePlusPR,
+		OutputNot: duty.OutputNote,
+	}
+	s.renderPage(w, "duties", data)
+}

--- a/internal/server/duties_test.go
+++ b/internal/server/duties_test.go
@@ -1,0 +1,98 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/bupd/night-family/internal/duty"
+)
+
+func newTestServerWithDuties(t *testing.T) *Server {
+	t.Helper()
+	s, err := New(Config{
+		Addr:   "127.0.0.1:0",
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Duties: duty.NewBuiltinRegistry(),
+	})
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+	return s
+}
+
+func TestListDuties(t *testing.T) {
+	s := newTestServerWithDuties(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/duties", nil)
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var list []map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &list); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if len(list) < 18 {
+		t.Fatalf("duty count = %d, want >= 18", len(list))
+	}
+	types := map[string]bool{}
+	for _, d := range list {
+		types[d["type"].(string)] = true
+	}
+	for _, want := range []string{"vuln-scan", "lint-fix", "docs-drift", "todo-triage"} {
+		if !types[want] {
+			t.Errorf("duty catalogue missing %q", want)
+		}
+	}
+}
+
+func TestGetDutyHit(t *testing.T) {
+	s := newTestServerWithDuties(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/duties/lint-fix", nil)
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var info map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &info); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if info["type"] != "lint-fix" {
+		t.Fatalf("type = %v, want lint-fix", info["type"])
+	}
+}
+
+func TestGetDutyMiss(t *testing.T) {
+	s := newTestServerWithDuties(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/duties/does-not-exist", nil)
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rr.Code)
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/problem+json" {
+		t.Fatalf("content-type = %q, want application/problem+json", ct)
+	}
+}
+
+func TestDutiesPageRenders(t *testing.T) {
+	s := newTestServerWithDuties(t)
+	req := httptest.NewRequest(http.MethodGet, "/duties", nil)
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	body := rr.Body.String()
+	for _, want := range []string{"vuln-scan", "lint-fix", "Duties"} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -17,6 +17,7 @@ import (
 	"net/http"
 	"time"
 
+	"github.com/bupd/night-family/internal/duty"
 	"github.com/bupd/night-family/internal/family"
 	"github.com/bupd/night-family/internal/version"
 )
@@ -39,6 +40,9 @@ type Config struct {
 	// Family is the in-memory store the /family* handlers read from.
 	// When nil, the family routes are not registered.
 	Family *family.Store
+	// Duties is the duty registry the /duties* handlers read from. When
+	// nil, those routes are not registered.
+	Duties *duty.Registry
 }
 
 // Server is the running HTTP server.
@@ -104,6 +108,7 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /openapi.json", s.serveOpenAPIJSON)
 	mux.HandleFunc("GET /docs", s.serveDocs)
 	s.familyRoutes(mux)
+	s.dutiesRoutes(mux)
 	mux.HandleFunc("GET /", s.index)
 
 	if staticSub, err := fs.Sub(s.web, "static"); err == nil {
@@ -163,6 +168,7 @@ func parsePages(web fs.FS) (map[string]*template.Template, error) {
 		"index":  "templates/index.html.tmpl",
 		"docs":   "templates/docs.html.tmpl",
 		"family": "templates/family.html.tmpl",
+		"duties": "templates/duties.html.tmpl",
 	}
 	out := make(map[string]*template.Template, len(pages))
 	for name, path := range pages {

--- a/internal/server/web/templates/duties.html.tmpl
+++ b/internal/server/web/templates/duties.html.tmpl
@@ -1,0 +1,24 @@
+{{define "content"}}
+<section class="nf-hero">
+  <h1>Duties</h1>
+  <p class="nf-tagline">
+    {{len .Duties}} duty type{{if ne (len .Duties) 1}}s{{end}} registered.
+    <a href="/api/v1/duties">raw JSON</a>.
+  </p>
+</section>
+
+<section class="nf-grid">
+  {{range .Duties}}
+  <article class="nf-card">
+    <h2>{{.Type}}</h2>
+    <p>{{.Description}}</p>
+    <dl class="nf-meta">
+      <dt>Output</dt><dd><code>{{.Output}}</code></dd>
+      <dt>Cost</dt><dd>{{.CostTier}}</dd>
+      <dt>Risk</dt><dd>{{.Risk}}</dd>
+      <dt>Built-in</dt><dd>{{if .Builtin}}yes{{else}}no{{end}}</dd>
+    </dl>
+  </article>
+  {{end}}
+</section>
+{{end}}


### PR DESCRIPTION
## Summary

Iteration 5: night-family now knows what duties exist. The 18-entry catalogue from \`docs/DUTIES.md\` is promoted into a registry package, exposed over the API, rendered in the UI, and queryable from the CLI.

## What's in the box

- **\`internal/duty\`** — name-keyed \`Registry\` with \`Register\`/\`Get\`/\`Has\`/\`List\`/\`Len\`. Thread-safe for concurrent reads. \`Info\` captures \`Type\`, \`Description\`, \`Output\` (pr / issue / issue-plus-pr / note), \`CostTier\`, \`Risk\`, \`Builtin\`.
- **\`Builtins()\`** — the canonical 18-duty catalogue, every entry cross-checked against the default roster's duty references in tests.
- **Server** — \`GET /api/v1/duties\`, \`GET /api/v1/duties/{type}\`, \`GET /duties\`. Missing type ⇒ RFC 9457 \`application/problem+json\` 404.
- **\`nfd\`** loads the built-in registry at startup alongside the family store; logs count on boot.
- **\`nf duty list\` / \`nf duty show <type>\`** — mirrors the family commands; tabwriter output with \`--json\` opt-in.

## Why a separate package

Put \`duty\` in its own package (not inside \`family\`) so the validator, the future planner, and the API handlers all share the same catalogue without any of them pulling in provider code. \`internal/duty\` is deliberately side-effect-free.

## Test plan

- [x] \`task check\` passes
- [x] \`nfd\` logs \`duties loaded count=18\`
- [x] \`nf duty list\` prints the 18 types with tabwriter
- [x] \`curl /api/v1/duties/ghost\` → 404 \`application/problem+json\`
- [x] \`/duties\` HTMX page renders
- [ ] CI green

## Follow-ups

- Cross-check member \`duty.Type\` against the registry in \`family.Validate\` (warn rather than fail so custom prompt-only duties stay legal).
- \`POST /duties/{type}/plan\` once planners exist.
- Custom prompt-only duty loader.

cc @coderabbitai @cubic-dev-ai — worth checking the catalogue entries match \`docs/DUTIES.md\` and the Output enum covers everything the planner/orchestrator will need.

🤖 Generated with [Claude Code](https://claude.com/claude-code)