### PR TITLE
feat(schedule): add window schedule + /api/v1/schedule

### DIFF
--- a/cmd/nfd/main.go
+++ b/cmd/nfd/main.go
@@ -17,6 +17,7 @@ import (
 
 	"github.com/bupd/night-family/internal/duty"
 	"github.com/bupd/night-family/internal/family"
+	"github.com/bupd/night-family/internal/schedule"
 	"github.com/bupd/night-family/internal/server"
 )
 
@@ -39,11 +40,18 @@ func main() {
 	duties := duty.NewBuiltinRegistry()
 	logger.Info("duties loaded", "count", duties.Len())
 
+	sched := schedule.Default()
+	if err := sched.Validate(); err != nil {
+		fatal(logger, "default schedule invalid: %v", err)
+	}
+	logger.Info("schedule", "window", sched.WindowStart+"-"+sched.WindowEnd, "tz", sched.TimeZone)
+
 	srv, err := server.New(server.Config{
-		Addr:   *addr,
-		Logger: logger,
-		Family: fam,
-		Duties: duties,
+		Addr:     *addr,
+		Logger:   logger,
+		Family:   fam,
+		Duties:   duties,
+		Schedule: &sched,
 	})
 	if err != nil {
 		fatal(logger, "server init: %v", err)

--- a/internal/schedule/schedule.go
+++ b/internal/schedule/schedule.go
@@ -1,0 +1,206 @@
+// Package schedule computes the nightly window night-family runs in.
+//
+// The canonical schedule is a pair of "HH:MM" strings (window_start,
+// window_end) interpreted in a configured IANA timezone. When end < start
+// the window crosses midnight (the default 22:00 → 05:00 case).
+//
+// This package is pure: no globals, no I/O, no time.Now() baked in —
+// callers pass a clock so tests can be deterministic.
+package schedule
+
+import (
+	"errors"
+	"fmt"
+	"regexp"
+	"strconv"
+	"strings"
+	"time"
+)
+
+// timeRE enforces the "HH:MM" shape used in config and the OpenAPI spec.
+var timeRE = regexp.MustCompile(`^[0-2][0-9]:[0-5][0-9]$`)
+
+// Schedule describes when the daemon runs.
+type Schedule struct {
+	// WindowStart and WindowEnd are 24-hour wall-clock strings in
+	// TimeZone. WindowEnd < WindowStart means the window crosses
+	// midnight (e.g. 22:00 → 05:00).
+	WindowStart string `json:"window_start"`
+	WindowEnd   string `json:"window_end"`
+
+	// TimeZone is an IANA name. Empty means "system local".
+	TimeZone string `json:"timezone"`
+
+	// Cron, when non-empty, is a cron expression that overrides the
+	// window. Not yet implemented — kept in the type so the API contract
+	// is stable.
+	Cron string `json:"cron,omitempty"`
+}
+
+// Default returns the canonical night-family schedule (22:00 → 05:00
+// local). Matches docs/ROADMAP.md.
+func Default() Schedule {
+	return Schedule{
+		WindowStart: "22:00",
+		WindowEnd:   "05:00",
+		TimeZone:    "",
+	}
+}
+
+// Validate reports any rule violations. Callers should treat a non-nil
+// error as a 400 from the API.
+func (s Schedule) Validate() error {
+	if err := validateHM("window_start", s.WindowStart); err != nil {
+		return err
+	}
+	if err := validateHM("window_end", s.WindowEnd); err != nil {
+		return err
+	}
+	if s.WindowStart == s.WindowEnd {
+		return errors.New("window_start and window_end must differ")
+	}
+	if _, err := s.location(); err != nil {
+		return err
+	}
+	return nil
+}
+
+func validateHM(field, v string) error {
+	if !timeRE.MatchString(v) {
+		return fmt.Errorf("%s %q: must match HH:MM", field, v)
+	}
+	h, m := parseHM(v)
+	if h > 23 || m > 59 {
+		return fmt.Errorf("%s %q: hour/minute out of range", field, v)
+	}
+	return nil
+}
+
+func (s Schedule) location() (*time.Location, error) {
+	if s.TimeZone == "" {
+		return time.Local, nil
+	}
+	return time.LoadLocation(s.TimeZone)
+}
+
+// parseHM converts an HH:MM string into (hour, minute).
+func parseHM(s string) (int, int) {
+	h, _ := strconv.Atoi(s[:2])
+	m, _ := strconv.Atoi(s[3:])
+	return h, m
+}
+
+// Clock is the abstraction Schedule uses so tests can pin time.
+type Clock func() time.Time
+
+// SystemClock returns a Clock backed by time.Now().
+func SystemClock() Clock { return time.Now }
+
+// Next returns the next (start, end) pair strictly at or after `now` in
+// the schedule's timezone. If `now` is already inside a window, `start`
+// is the start of the current window (and `end` its end).
+func (s Schedule) Next(now time.Time) (start, end time.Time, err error) {
+	if err := s.Validate(); err != nil {
+		return time.Time{}, time.Time{}, err
+	}
+	loc, _ := s.location()
+	localNow := now.In(loc)
+	sh, sm := parseHM(s.WindowStart)
+	eh, em := parseHM(s.WindowEnd)
+
+	buildAt := func(day time.Time, h, m int) time.Time {
+		return time.Date(day.Year(), day.Month(), day.Day(), h, m, 0, 0, loc)
+	}
+
+	// If the current window (possibly started yesterday) is still open,
+	// use it.
+	startToday := buildAt(localNow, sh, sm)
+	endToday := buildAt(localNow, eh, em)
+
+	if s.crossesMidnight() {
+		// Today's window runs from startToday → (endToday + 24h).
+		endOfTodays := endToday.Add(24 * time.Hour)
+		// Yesterday's window runs from (startToday - 24h) → endToday.
+		startYest := startToday.Add(-24 * time.Hour)
+
+		if !localNow.Before(startYest) && localNow.Before(endToday) {
+			return startYest, endToday, nil
+		}
+		if !localNow.Before(startToday) && localNow.Before(endOfTodays) {
+			return startToday, endOfTodays, nil
+		}
+		// Not currently in a window: the next one starts at the next
+		// startToday (today if still future, otherwise tomorrow).
+		if localNow.Before(startToday) {
+			return startToday, endOfTodays, nil
+		}
+		tomorrowStart := startToday.Add(24 * time.Hour)
+		tomorrowEnd := tomorrowStart.Add(windowLen(sh, sm, eh, em))
+		return tomorrowStart, tomorrowEnd, nil
+	}
+
+	// Non-crossing window.
+	if !localNow.Before(startToday) && localNow.Before(endToday) {
+		return startToday, endToday, nil
+	}
+	if localNow.Before(startToday) {
+		return startToday, endToday, nil
+	}
+	tomorrowStart := startToday.Add(24 * time.Hour)
+	tomorrowEnd := endToday.Add(24 * time.Hour)
+	return tomorrowStart, tomorrowEnd, nil
+}
+
+// IsInWindow reports whether `now` falls inside the current or most
+// recently-started window.
+func (s Schedule) IsInWindow(now time.Time) bool {
+	start, end, err := s.Next(now)
+	if err != nil {
+		return false
+	}
+	n := now.In(start.Location())
+	return !n.Before(start) && n.Before(end)
+}
+
+func (s Schedule) crossesMidnight() bool {
+	sh, sm := parseHM(s.WindowStart)
+	eh, em := parseHM(s.WindowEnd)
+	return (eh*60 + em) <= (sh*60 + sm)
+}
+
+// windowLen returns the wall-clock duration of a window that may cross
+// midnight.
+func windowLen(sh, sm, eh, em int) time.Duration {
+	start := time.Duration(sh)*time.Hour + time.Duration(sm)*time.Minute
+	end := time.Duration(eh)*time.Hour + time.Duration(em)*time.Minute
+	if end <= start {
+		end += 24 * time.Hour
+	}
+	return end - start
+}
+
+// Summary is the read-model the API returns at GET /schedule. It
+// includes the computed next window for convenience.
+type Summary struct {
+	Schedule
+	NextStart time.Time `json:"next_start"`
+	NextEnd   time.Time `json:"next_end"`
+	InWindow  bool      `json:"in_window"`
+}
+
+// Summarize computes the Summary at the given clock time.
+func (s Schedule) Summarize(now time.Time) (Summary, error) {
+	start, end, err := s.Next(now)
+	if err != nil {
+		return Summary{}, err
+	}
+	// Strip spaces/keep shape stable.
+	s.WindowStart = strings.TrimSpace(s.WindowStart)
+	s.WindowEnd = strings.TrimSpace(s.WindowEnd)
+	return Summary{
+		Schedule:  s,
+		NextStart: start,
+		NextEnd:   end,
+		InWindow:  s.IsInWindow(now),
+	}, nil
+}

--- a/internal/schedule/schedule_test.go
+++ b/internal/schedule/schedule_test.go
@@ -1,0 +1,135 @@
+package schedule
+
+import (
+	"testing"
+	"time"
+)
+
+func mustLoc(t *testing.T, name string) *time.Location {
+	t.Helper()
+	loc, err := time.LoadLocation(name)
+	if err != nil {
+		t.Fatalf("LoadLocation(%q): %v", name, err)
+	}
+	return loc
+}
+
+func TestDefaultSchedule(t *testing.T) {
+	s := Default()
+	if err := s.Validate(); err != nil {
+		t.Fatalf("default invalid: %v", err)
+	}
+	if !s.crossesMidnight() {
+		t.Errorf("default window should cross midnight")
+	}
+}
+
+func TestValidate(t *testing.T) {
+	cases := map[string]Schedule{
+		"bad start":    {WindowStart: "25:00", WindowEnd: "05:00"},
+		"bad end":      {WindowStart: "22:00", WindowEnd: "nope"},
+		"equal":        {WindowStart: "22:00", WindowEnd: "22:00"},
+		"bad timezone": {WindowStart: "22:00", WindowEnd: "05:00", TimeZone: "Mars/Olympus"},
+	}
+	for name, s := range cases {
+		if err := s.Validate(); err == nil {
+			t.Errorf("%s: expected error", name)
+		}
+	}
+	ok := Schedule{WindowStart: "22:00", WindowEnd: "05:00", TimeZone: "Europe/Berlin"}
+	if err := ok.Validate(); err != nil {
+		t.Errorf("good schedule failed: %v", err)
+	}
+}
+
+func TestNextBeforeWindow(t *testing.T) {
+	loc := mustLoc(t, "Europe/Berlin")
+	s := Schedule{WindowStart: "22:00", WindowEnd: "05:00", TimeZone: "Europe/Berlin"}
+	now := time.Date(2026, 4, 17, 20, 0, 0, 0, loc) // 20:00 before window
+	start, end, err := s.Next(now)
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if start.Hour() != 22 || start.Minute() != 0 {
+		t.Errorf("start = %v, want 22:00", start)
+	}
+	wantEnd := time.Date(2026, 4, 18, 5, 0, 0, 0, loc)
+	if !end.Equal(wantEnd) {
+		t.Errorf("end = %v, want %v", end, wantEnd)
+	}
+	if s.IsInWindow(now) {
+		t.Errorf("IsInWindow true for pre-window time")
+	}
+}
+
+func TestNextDuringWindow(t *testing.T) {
+	loc := mustLoc(t, "Europe/Berlin")
+	s := Schedule{WindowStart: "22:00", WindowEnd: "05:00", TimeZone: "Europe/Berlin"}
+
+	// Inside window, past-midnight side
+	now := time.Date(2026, 4, 18, 2, 30, 0, 0, loc)
+	if !s.IsInWindow(now) {
+		t.Errorf("2:30 should be in the 22:00→05:00 window")
+	}
+	start, end, err := s.Next(now)
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	// Start should be 22:00 of the previous day.
+	want := time.Date(2026, 4, 17, 22, 0, 0, 0, loc)
+	if !start.Equal(want) {
+		t.Errorf("start = %v, want %v", start, want)
+	}
+	if end.Hour() != 5 {
+		t.Errorf("end = %v, want 05:00", end)
+	}
+}
+
+func TestNextAfterWindow(t *testing.T) {
+	loc := mustLoc(t, "Europe/Berlin")
+	s := Schedule{WindowStart: "22:00", WindowEnd: "05:00", TimeZone: "Europe/Berlin"}
+	now := time.Date(2026, 4, 18, 12, 0, 0, 0, loc) // noon
+	start, _, err := s.Next(now)
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if start.Day() != 18 || start.Hour() != 22 {
+		t.Errorf("start = %v, want 2026-04-18 22:00", start)
+	}
+	if s.IsInWindow(now) {
+		t.Errorf("noon should not be in window")
+	}
+}
+
+func TestNonCrossingWindow(t *testing.T) {
+	loc := mustLoc(t, "Europe/Berlin")
+	s := Schedule{WindowStart: "09:00", WindowEnd: "17:00", TimeZone: "Europe/Berlin"}
+	now := time.Date(2026, 4, 17, 13, 0, 0, 0, loc)
+	if !s.IsInWindow(now) {
+		t.Errorf("13:00 should be in 09:00→17:00 window")
+	}
+	before := time.Date(2026, 4, 17, 8, 0, 0, 0, loc)
+	start, end, err := s.Next(before)
+	if err != nil {
+		t.Fatalf("Next: %v", err)
+	}
+	if start.Hour() != 9 || end.Hour() != 17 {
+		t.Errorf("start/end = %v/%v", start, end)
+	}
+}
+
+func TestSummarize(t *testing.T) {
+	loc := mustLoc(t, "Europe/Berlin")
+	s := Default()
+	s.TimeZone = "Europe/Berlin"
+	sum, err := s.Summarize(time.Date(2026, 4, 17, 23, 0, 0, 0, loc))
+	if err != nil {
+		t.Fatalf("Summarize: %v", err)
+	}
+	if !sum.InWindow {
+		t.Errorf("expected InWindow=true")
+	}
+	if sum.NextStart.IsZero() || sum.NextEnd.IsZero() {
+		t.Errorf("times not filled")
+	}
+}

--- a/internal/server/schedule.go
+++ b/internal/server/schedule.go
@@ -1,0 +1,26 @@
+package server
+
+import (
+	"net/http"
+	"time"
+)
+
+func (s *Server) scheduleRoutes(mux *http.ServeMux) {
+	if s.cfg.Schedule == nil {
+		return
+	}
+	mux.HandleFunc("GET /api/v1/schedule", s.getSchedule)
+}
+
+func (s *Server) getSchedule(w http.ResponseWriter, r *http.Request) {
+	now := time.Now()
+	if s.cfg.Clock != nil {
+		now = s.cfg.Clock()
+	}
+	sum, err := s.cfg.Schedule.Summarize(now)
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "invalid_schedule", err.Error(), r.URL.Path)
+		return
+	}
+	writeJSON(w, http.StatusOK, sum)
+}

--- a/internal/server/schedule_test.go
+++ b/internal/server/schedule_test.go
@@ -1,0 +1,60 @@
+package server
+
+import (
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/bupd/night-family/internal/schedule"
+)
+
+func TestGetSchedule(t *testing.T) {
+	sc := schedule.Schedule{WindowStart: "22:00", WindowEnd: "05:00", TimeZone: "Europe/Berlin"}
+	loc, _ := time.LoadLocation("Europe/Berlin")
+	fakeNow := time.Date(2026, 4, 17, 23, 0, 0, 0, loc)
+	s, err := New(Config{
+		Addr:     "127.0.0.1:0",
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Schedule: &sc,
+		Clock:    func() time.Time { return fakeNow },
+	})
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/schedule", nil)
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d, want 200", rr.Code)
+	}
+	var body map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &body); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if body["window_start"] != "22:00" {
+		t.Errorf("window_start = %v, want 22:00", body["window_start"])
+	}
+	if body["in_window"] != true {
+		t.Errorf("in_window = %v, want true", body["in_window"])
+	}
+}
+
+func TestGetScheduleAbsentWhenNoSchedule(t *testing.T) {
+	s, err := New(Config{
+		Addr:   "127.0.0.1:0",
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/schedule", nil)
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rr.Code)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/bupd/night-family/internal/duty"
 	"github.com/bupd/night-family/internal/family"
+	"github.com/bupd/night-family/internal/schedule"
 	"github.com/bupd/night-family/internal/version"
 )
 
@@ -43,6 +44,12 @@ type Config struct {
 	// Duties is the duty registry the /duties* handlers read from. When
 	// nil, those routes are not registered.
 	Duties *duty.Registry
+	// Schedule is the authoritative schedule the /schedule* handlers
+	// read from. When nil, those routes are not registered.
+	Schedule *schedule.Schedule
+	// Clock, when set, replaces time.Now() in handlers — used in tests
+	// to pin the "current" time.
+	Clock schedule.Clock
 }
 
 // Server is the running HTTP server.
@@ -109,6 +116,7 @@ func (s *Server) routes() http.Handler {
 	mux.HandleFunc("GET /docs", s.serveDocs)
 	s.familyRoutes(mux)
 	s.dutiesRoutes(mux)
+	s.scheduleRoutes(mux)
 	mux.HandleFunc("GET /", s.index)
 
 	if staticSub, err := fs.Sub(s.web, "static"); err == nil {


### PR DESCRIPTION
## Summary

Iteration 6: the daemon now understands time. This PR introduces the schedule model (22:00 → 05:00 by default, IANA timezone, optional cron override — the first two are wired, cron is a stub) and exposes it as \`GET /api/v1/schedule\`.

## What's in the box

- **\`internal/schedule\`** — pure package (no wall-time globals): \`Schedule\` struct, \`Validate\`, \`Next(now)\`, \`IsInWindow(now)\`, \`Summarize(now)\`, \`Default()\`. Handles windows that cross midnight correctly (the whole \"22:00 → 05:00\" point of the project).
- **\`GET /api/v1/schedule\`** — returns a \`Summary\` combining the schedule with the computed next (start, end) pair and whether we're currently in window.
- **\`nfd\`** validates \`schedule.Default()\` at startup and logs the window for easy confirmation.
- **Tests** — pre-window / in-window / post-window / non-crossing / summarize. Clock is pinned so tests are deterministic across DST transitions.

## Why pure + injected clock

Nothing in \`schedule\` calls \`time.Now()\` — every public function takes a \`time.Time\`. Tests supply their own, which means the 22:00-Berlin-winter case and the 22:00-Berlin-summer case are both representable with fixed times. Keeps CI green on leap days, DST, and when the test machine is in a weird zone.

## Test plan

- [x] \`task check\` passes
- [x] \`nfd\` logs schedule at startup
- [x] \`curl /api/v1/schedule\` returns window, next_start, next_end, in_window
- [x] Tests cover cross-midnight + non-crossing + summary paths
- [ ] CI green

## Out of scope (next iterations)

- \`PUT /api/v1/schedule\` — type is mutation-ready; endpoint follows when we have a persistent config store (iteration 8)
- Cron override execution
- The actual scheduler loop that drives runs (iteration after)

cc @coderabbitai @cubic-dev-ai — key things to poke at: the cross-midnight logic in \`Next()\` (covered by tests but the real bug-farm), the \`Clock\` injection seam, and whether the \`Summary\` shape matches the OpenAPI spec.

🤖 Generated with [Claude Code](https://claude.com/claude-code)