### PR TITLE
feat(runner): mock provider + POST /api/v1/runs dispatches a real Run

### DIFF
--- a/cmd/nf/client.go
+++ b/cmd/nf/client.go
@@ -1,6 +1,7 @@
 package main
 
 import (
+	"bytes"
 	"encoding/json"
 	"fmt"
 	"io"
@@ -20,6 +21,31 @@ func daemonURL() string {
 		return u
 	}
 	return defaultDaemonURL
+}
+
+// apiPost sends a JSON POST and decodes the response. Non-2xx is
+// surfaced as an error.
+func apiPost(path string, body []byte, out any) error {
+	c := &http.Client{Timeout: 3 * time.Minute}
+	req, err := http.NewRequest(http.MethodPost, daemonURL()+path, bytes.NewReader(body))
+	if err != nil {
+		return err
+	}
+	req.Header.Set("Content-Type", "application/json")
+	req.Header.Set("Accept", "application/json")
+	resp, err := c.Do(req)
+	if err != nil {
+		return fmt.Errorf("reach daemon at %s: %w", daemonURL(), err)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode/100 != 2 {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		return fmt.Errorf("daemon returned %s: %s", resp.Status, string(b))
+	}
+	if out == nil {
+		return nil
+	}
+	return json.NewDecoder(resp.Body).Decode(out)
 }
 
 // apiGet fetches and decodes a JSON document from the daemon. Any

--- a/cmd/nf/run.go
+++ b/cmd/nf/run.go
@@ -9,11 +9,12 @@ import (
 	"text/tabwriter"
 )
 
-const runUsage = `nf run — inspect recorded runs
+const runUsage = `nf run — inspect and dispatch runs
 
 Usage:
   nf run list [--member X] [--duty Y] [--status Z] [--limit N] [--json]
   nf run show <id>
+  nf run start --member X --duty Y        Dispatch a new run against the daemon's provider
 `
 
 type runRecord struct {
@@ -42,6 +43,8 @@ func runCmd(args []string) {
 		runList(args[1:])
 	case "show":
 		runShow(args[1:])
+	case "start":
+		runStart(args[1:])
 	case "help", "-h", "--help":
 		fmt.Print(runUsage)
 	default:
@@ -104,6 +107,30 @@ func runList(args []string) {
 			r.ID, r.Member, r.Duty, r.Status, r.StartedAt, pr)
 	}
 	_ = tw.Flush()
+}
+
+func runStart(args []string) {
+	fs := flag.NewFlagSet("run start", flag.ExitOnError)
+	member := fs.String("member", "", "family member name (required)")
+	duty := fs.String("duty", "", "duty type (required)")
+	_ = fs.Parse(args)
+	if *member == "" || *duty == "" {
+		fmt.Fprintln(os.Stderr, "nf run start: --member and --duty are required")
+		os.Exit(2)
+	}
+	body, err := json.Marshal(map[string]any{"member": *member, "duty": *duty})
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "nf:", err)
+		os.Exit(1)
+	}
+	var run map[string]any
+	if err := apiPost("/api/v1/runs", body, &run); err != nil {
+		fmt.Fprintln(os.Stderr, "nf:", err)
+		os.Exit(1)
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(run)
 }
 
 func runShow(args []string) {

--- a/cmd/nfd/main.go
+++ b/cmd/nfd/main.go
@@ -17,6 +17,8 @@ import (
 
 	"github.com/bupd/night-family/internal/duty"
 	"github.com/bupd/night-family/internal/family"
+	"github.com/bupd/night-family/internal/provider"
+	"github.com/bupd/night-family/internal/runner"
 	"github.com/bupd/night-family/internal/schedule"
 	"github.com/bupd/night-family/internal/server"
 	"github.com/bupd/night-family/internal/storage"
@@ -54,6 +56,19 @@ func main() {
 	}
 	defer db.Close()
 
+	prov := provider.NewMock()
+	logger.Info("provider", "name", prov.Name())
+	run, err := runner.New(runner.Deps{
+		Family:   fam,
+		Duties:   duties,
+		Storage:  db,
+		Provider: prov,
+		Logger:   logger,
+	})
+	if err != nil {
+		fatal(logger, "runner: %v", err)
+	}
+
 	srv, err := server.New(server.Config{
 		Addr:     *addr,
 		Logger:   logger,
@@ -61,6 +76,7 @@ func main() {
 		Duties:   duties,
 		Schedule: &sched,
 		Storage:  db,
+		Runner:   run,
 	})
 	if err != nil {
 		fatal(logger, "server init: %v", err)

--- a/go.mod
+++ b/go.mod
@@ -7,6 +7,7 @@ require (
 	github.com/google/uuid v1.6.0 // indirect
 	github.com/mattn/go-isatty v0.0.20 // indirect
 	github.com/ncruces/go-strftime v1.0.0 // indirect
+	github.com/oklog/ulid/v2 v2.1.1 // indirect
 	github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec // indirect
 	golang.org/x/sys v0.42.0 // indirect
 	gopkg.in/yaml.v3 v3.0.1 // indirect

--- a/go.sum
+++ b/go.sum
@@ -6,6 +6,9 @@ github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWE
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
 github.com/ncruces/go-strftime v1.0.0 h1:HMFp8mLCTPp341M/ZnA4qaf7ZlsbTc+miZjCLOFAw7w=
 github.com/ncruces/go-strftime v1.0.0/go.mod h1:Fwc5htZGVVkseilnfgOVb9mKy6w1naJmn9CehxcKcls=
+github.com/oklog/ulid/v2 v2.1.1 h1:suPZ4ARWLOJLegGFiZZ1dFAkqzhMjL3J1TzI+5wHz8s=
+github.com/oklog/ulid/v2 v2.1.1/go.mod h1:rcEKHmBBKfef9DhnvX7y1HZBYxjXb0cP5ExxNsTT1QQ=
+github.com/pborman/getopt v0.0.0-20170112200414-7148bc3a4c30/go.mod h1:85jBQOZwpVEaDAr341tbn15RS4fCAsIst0qp7i8ex1o=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec h1:W09IVJc94icq4NjY3clb7Lk8O1qJ8BdBEF8z0ibU0rE=
 github.com/remyoudompheng/bigfft v0.0.0-20230129092748-24d4a6f8daec/go.mod h1:qqbHyh8v60DhA7CoWK5oRCqLrMHRGoxYCSS9EjAz6Eo=
 golang.org/x/sys v0.6.0/go.mod h1:oPkhp1MJrh7nUepCBck5+mAzfO9JrbApNNgaTdGDITg=

--- a/internal/provider/mock.go
+++ b/internal/provider/mock.go
@@ -1,0 +1,56 @@
+package provider
+
+import (
+	"context"
+	"fmt"
+	"time"
+)
+
+// Mock is a zero-side-effect provider used in tests, local
+// development, and the v1 daemon before a real adapter is wired.
+// Every Run call returns a canned Result after a configurable delay,
+// making it easy to exercise the full runner → storage → API path
+// without hitting the network or spawning a subprocess.
+type Mock struct {
+	// Delay is how long Run pretends to work for.
+	Delay time.Duration
+	// TokensIn / TokensOut are what Run reports as consumed.
+	TokensIn, TokensOut int
+	// FailMember, when non-empty, causes Run to return an error for
+	// requests coming from that member — lets tests exercise the
+	// failed-run path.
+	FailMember string
+}
+
+// NewMock returns a Mock with sensible defaults.
+func NewMock() *Mock {
+	return &Mock{
+		Delay:     20 * time.Millisecond,
+		TokensIn:  1234,
+		TokensOut: 567,
+	}
+}
+
+// Name is "mock".
+func (m *Mock) Name() string { return "mock" }
+
+// Run implements Provider. Honours ctx cancellation.
+func (m *Mock) Run(ctx context.Context, req Request) (*Result, error) {
+	if m.FailMember != "" && req.Member == m.FailMember {
+		return &Result{Err: fmt.Errorf("mock: forced failure for member %q", req.Member)}, nil
+	}
+	select {
+	case <-time.After(m.Delay):
+	case <-ctx.Done():
+		return &Result{Err: ctx.Err()}, ctx.Err()
+	}
+	return &Result{
+		Summary: fmt.Sprintf(
+			"[mock] %s/%s completed — no real changes made. "+
+				"This is a simulated run so the rest of the pipeline can "+
+				"be tested end-to-end without burning provider tokens.",
+			req.Member, req.Duty),
+		TokensIn:  m.TokensIn,
+		TokensOut: m.TokensOut,
+	}, nil
+}

--- a/internal/provider/provider.go
+++ b/internal/provider/provider.go
@@ -1,0 +1,39 @@
+// Package provider abstracts over the LLM-backed runtime that actually
+// does a duty's work. v1 ships with a single adapter — the noop/mock
+// provider — so the rest of the system can be built and tested without
+// burning real tokens. Real adapters (Claude Code, Codex) land in
+// follow-up iterations.
+package provider
+
+import "context"
+
+// Request is what the runner hands to a provider when dispatching a
+// duty. Everything a provider needs to form its prompt is here: the
+// member's system prompt, the duty type, the repository root, and
+// anything extra the duty-specific planner attached as Args.
+type Request struct {
+	Member        string
+	MemberPrompt  string
+	Duty          string
+	DutyPrompt    string
+	RepoRoot      string
+	Args          map[string]any
+	EstimatedToks int
+}
+
+// Result is what a provider returns after a run completes (or fails).
+// Token counts are optional — not every provider reports them.
+type Result struct {
+	Summary   string
+	Branch    string
+	PRURL     string
+	TokensIn  int
+	TokensOut int
+	Err       error
+}
+
+// Provider is the seam a runner calls to execute one duty.
+type Provider interface {
+	Name() string
+	Run(ctx context.Context, req Request) (*Result, error)
+}

--- a/internal/runner/runner.go
+++ b/internal/runner/runner.go
@@ -1,0 +1,145 @@
+// Package runner dispatches a single (member, duty) pair through a
+// provider, persisting the lifecycle to storage.
+//
+// Runs go queued → running → (succeeded | failed | cancelled). Every
+// transition is recorded, so the API can report progress live.
+package runner
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+	"time"
+
+	"github.com/bupd/night-family/internal/duty"
+	"github.com/bupd/night-family/internal/family"
+	"github.com/bupd/night-family/internal/provider"
+	"github.com/bupd/night-family/internal/storage"
+	"github.com/bupd/night-family/internal/ulid"
+)
+
+// Deps are the runtime dependencies a Runner needs.
+type Deps struct {
+	Family   *family.Store
+	Duties   *duty.Registry
+	Storage  *storage.DB
+	Provider provider.Provider
+	Logger   *slog.Logger
+	// RepoRoot is the path passed to providers as the working dir.
+	RepoRoot string
+}
+
+// Runner orchestrates one-off duty execution.
+type Runner struct {
+	deps Deps
+}
+
+// New returns a Runner with the given deps. All fields except
+// RepoRoot must be non-nil.
+func New(deps Deps) (*Runner, error) {
+	if deps.Family == nil || deps.Duties == nil || deps.Storage == nil || deps.Provider == nil || deps.Logger == nil {
+		return nil, fmt.Errorf("runner: all deps (Family/Duties/Storage/Provider/Logger) required")
+	}
+	return &Runner{deps: deps}, nil
+}
+
+// DispatchRequest is what callers hand to Dispatch.
+type DispatchRequest struct {
+	Member  string
+	Duty    string
+	NightID *string
+	Args    map[string]any
+}
+
+// Dispatch creates a queued Run, transitions it to running, invokes
+// the provider, and records the terminal state. Returns the final
+// Run as stored.
+func (r *Runner) Dispatch(ctx context.Context, req DispatchRequest) (storage.Run, error) {
+	member, err := r.deps.Family.Get(req.Member)
+	if err != nil {
+		return storage.Run{}, fmt.Errorf("runner: family.Get %q: %w", req.Member, err)
+	}
+	info, known := r.deps.Duties.Get(req.Duty)
+	if !known {
+		// Prompt-only duty fallback: keep going with best-guess info.
+		info = duty.Info{Type: req.Duty, Output: duty.OutputNote, CostTier: family.CostMedium, Risk: family.RiskMedium}
+	}
+
+	now := time.Now().UTC()
+	run := storage.Run{
+		ID:        ulid.Make("run"),
+		NightID:   req.NightID,
+		Member:    member.Name,
+		Duty:      req.Duty,
+		Status:    storage.RunQueued,
+		StartedAt: now,
+	}
+	if err := r.deps.Storage.InsertRun(ctx, run); err != nil {
+		return storage.Run{}, fmt.Errorf("runner: insert: %w", err)
+	}
+
+	// Transition to running.
+	if err := r.deps.Storage.UpdateRunStatus(ctx, run.ID, storage.RunRunning, nil, nil, nil, nil, nil); err != nil {
+		return storage.Run{}, fmt.Errorf("runner: mark running: %w", err)
+	}
+	r.deps.Logger.Info("run dispatched", "run", run.ID, "member", run.Member, "duty", run.Duty)
+
+	pReq := provider.Request{
+		Member:       member.Name,
+		MemberPrompt: member.SystemPrompt,
+		Duty:         req.Duty,
+		DutyPrompt:   info.Description,
+		RepoRoot:     r.deps.RepoRoot,
+		Args:         req.Args,
+	}
+	res, callErr := r.deps.Provider.Run(ctx, pReq)
+
+	finished := time.Now().UTC()
+	status := storage.RunSucceeded
+	var errMsg *string
+	var summary *string
+	var tokensIn, tokensOut *int
+
+	if callErr != nil {
+		status = storage.RunFailed
+		msg := callErr.Error()
+		errMsg = &msg
+	} else if res != nil && res.Err != nil {
+		status = storage.RunFailed
+		msg := res.Err.Error()
+		errMsg = &msg
+	} else if res != nil {
+		if res.Summary != "" {
+			s := res.Summary
+			summary = &s
+		}
+		if res.TokensIn > 0 {
+			v := res.TokensIn
+			tokensIn = &v
+		}
+		if res.TokensOut > 0 {
+			v := res.TokensOut
+			tokensOut = &v
+		}
+	}
+
+	if err := r.deps.Storage.UpdateRunStatus(ctx, run.ID, status, &finished, tokensIn, tokensOut, summary, errMsg); err != nil {
+		return storage.Run{}, fmt.Errorf("runner: mark terminal: %w", err)
+	}
+	r.deps.Logger.Info("run finished",
+		"run", run.ID, "status", status,
+		"tokens_in", deref(tokensIn), "tokens_out", deref(tokensOut))
+
+	final, err := r.deps.Storage.GetRun(ctx, run.ID)
+	if err != nil {
+		return storage.Run{}, fmt.Errorf("runner: reload: %w", err)
+	}
+	return final, nil
+}
+
+func deref(p *int) int {
+	if p == nil {
+		return 0
+	}
+	return *p
+}

--- a/internal/runner/runner_test.go
+++ b/internal/runner/runner_test.go
@@ -1,0 +1,113 @@
+package runner
+
+import (
+	"context"
+	"errors"
+	"io"
+	"log/slog"
+	"strings"
+	"testing"
+
+	"github.com/bupd/night-family/internal/duty"
+	"github.com/bupd/night-family/internal/family"
+	"github.com/bupd/night-family/internal/provider"
+	"github.com/bupd/night-family/internal/storage"
+)
+
+func newTestRunner(t *testing.T, p provider.Provider) (*Runner, *storage.DB) {
+	t.Helper()
+	fam := family.NewStore()
+	defaults, err := family.LoadDefaults()
+	if err != nil {
+		t.Fatalf("LoadDefaults: %v", err)
+	}
+	fam.Seed(defaults)
+	db, err := storage.Open(context.Background(), ":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	r, err := New(Deps{
+		Family:   fam,
+		Duties:   duty.NewBuiltinRegistry(),
+		Storage:  db,
+		Provider: p,
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	if err != nil {
+		t.Fatalf("New: %v", err)
+	}
+	return r, db
+}
+
+func TestDispatchSuccess(t *testing.T) {
+	mock := provider.NewMock()
+	r, db := newTestRunner(t, mock)
+	run, err := r.Dispatch(context.Background(), DispatchRequest{
+		Member: "jerry", Duty: "lint-fix",
+	})
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if run.Status != storage.RunSucceeded {
+		t.Errorf("status = %q, want succeeded", run.Status)
+	}
+	if run.Summary == nil || *run.Summary == "" {
+		t.Errorf("summary missing")
+	}
+	if run.TokensIn == nil || *run.TokensIn != mock.TokensIn {
+		t.Errorf("tokens_in = %v", run.TokensIn)
+	}
+	got, err := db.GetRun(context.Background(), run.ID)
+	if err != nil {
+		t.Fatalf("GetRun: %v", err)
+	}
+	if got.Status != storage.RunSucceeded {
+		t.Errorf("persisted status = %q", got.Status)
+	}
+}
+
+func TestDispatchUnknownMember(t *testing.T) {
+	r, _ := newTestRunner(t, provider.NewMock())
+	_, err := r.Dispatch(context.Background(), DispatchRequest{Member: "ghost", Duty: "lint-fix"})
+	if err == nil {
+		t.Fatalf("expected error for unknown member")
+	}
+}
+
+func TestDispatchRecordsFailure(t *testing.T) {
+	mock := provider.NewMock()
+	mock.FailMember = "jerry"
+	r, db := newTestRunner(t, mock)
+	run, err := r.Dispatch(context.Background(), DispatchRequest{Member: "jerry", Duty: "lint-fix"})
+	if err != nil {
+		t.Fatalf("Dispatch: %v", err)
+	}
+	if run.Status != storage.RunFailed {
+		t.Errorf("status = %q, want failed", run.Status)
+	}
+	if run.Error == nil || *run.Error == "" {
+		t.Errorf("error message missing")
+	}
+	persisted, _ := db.GetRun(context.Background(), run.ID)
+	if persisted.Status != storage.RunFailed {
+		t.Errorf("persisted status = %q", persisted.Status)
+	}
+}
+
+func TestDispatchCtxCancelledSurfaces(t *testing.T) {
+	ctx, cancel := context.WithCancel(context.Background())
+	cancel() // already cancelled before dispatch
+	r, _ := newTestRunner(t, provider.NewMock())
+	run, err := r.Dispatch(ctx, DispatchRequest{Member: "jerry", Duty: "lint-fix"})
+	// A cancelled context may either fail the INSERT (returning an
+	// error + empty Run) or make it through to a failed Run record —
+	// both are valid outcomes; we only want to be sure we don't
+	// silently succeed.
+	if err == nil && run.Status == storage.RunSucceeded {
+		t.Errorf("run succeeded despite cancelled context")
+	}
+	if err != nil && !errors.Is(err, context.Canceled) && !strings.Contains(err.Error(), "context canceled") {
+		t.Logf("non-cancel err (acceptable): %v", err)
+	}
+}

--- a/internal/server/runs.go
+++ b/internal/server/runs.go
@@ -2,11 +2,13 @@ package server
 
 import (
 	"context"
+	"encoding/json"
 	"errors"
 	"net/http"
 	"strconv"
 	"time"
 
+	"github.com/bupd/night-family/internal/runner"
 	"github.com/bupd/night-family/internal/storage"
 )
 
@@ -17,6 +19,41 @@ func (s *Server) runsRoutes(mux *http.ServeMux) {
 	mux.HandleFunc("GET /api/v1/runs", s.listRuns)
 	mux.HandleFunc("GET /api/v1/runs/{id}", s.getRun)
 	mux.HandleFunc("GET /runs", s.runsPage)
+	if s.cfg.Runner != nil {
+		mux.HandleFunc("POST /api/v1/runs", s.createRun)
+	}
+}
+
+type createRunRequest struct {
+	Member string         `json:"member"`
+	Duty   string         `json:"duty"`
+	Args   map[string]any `json:"args,omitempty"`
+}
+
+func (s *Server) createRun(w http.ResponseWriter, r *http.Request) {
+	var req createRunRequest
+	if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+		writeProblem(w, http.StatusBadRequest, "bad_request", "invalid JSON body: "+err.Error(), r.URL.Path)
+		return
+	}
+	if req.Member == "" || req.Duty == "" {
+		writeProblem(w, http.StatusBadRequest, "bad_request", "member and duty are required", r.URL.Path)
+		return
+	}
+	// Use a detached context with a generous timeout so the handler
+	// returns the final (not merely queued) run once the mock
+	// finishes. When providers get expensive we'll flip this to
+	// async + 202 Accepted.
+	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	defer cancel()
+	run, err := s.cfg.Runner.Dispatch(ctx, runner.DispatchRequest{
+		Member: req.Member, Duty: req.Duty, Args: req.Args,
+	})
+	if err != nil {
+		writeProblem(w, http.StatusBadRequest, "dispatch_failed", err.Error(), r.URL.Path)
+		return
+	}
+	writeJSON(w, http.StatusCreated, run)
 }
 
 func (s *Server) listRuns(w http.ResponseWriter, r *http.Request) {

--- a/internal/server/runs_post_test.go
+++ b/internal/server/runs_post_test.go
@@ -1,0 +1,99 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bupd/night-family/internal/duty"
+	"github.com/bupd/night-family/internal/family"
+	"github.com/bupd/night-family/internal/provider"
+	"github.com/bupd/night-family/internal/runner"
+	"github.com/bupd/night-family/internal/storage"
+)
+
+func newTestServerWithRunner(t *testing.T) *Server {
+	t.Helper()
+	fam := family.NewStore()
+	defaults, _ := family.LoadDefaults()
+	fam.Seed(defaults)
+	db, err := storage.Open(context.Background(), ":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	rn, err := runner.New(runner.Deps{
+		Family:   fam,
+		Duties:   duty.NewBuiltinRegistry(),
+		Storage:  db,
+		Provider: provider.NewMock(),
+		Logger:   logger,
+	})
+	if err != nil {
+		t.Fatalf("runner.New: %v", err)
+	}
+	s, err := New(Config{
+		Addr:    "127.0.0.1:0",
+		Logger:  logger,
+		Family:  fam,
+		Duties:  duty.NewBuiltinRegistry(),
+		Storage: db,
+		Runner:  rn,
+	})
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+	return s
+}
+
+func TestCreateRunSucceeds(t *testing.T) {
+	s := newTestServerWithRunner(t)
+	body, _ := json.Marshal(map[string]string{"member": "jerry", "duty": "lint-fix"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	var run map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &run); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	if run["status"] != "succeeded" {
+		t.Errorf("status = %v, want succeeded", run["status"])
+	}
+	if run["member"] != "jerry" {
+		t.Errorf("member = %v, want jerry", run["member"])
+	}
+}
+
+func TestCreateRunRejectsMissingFields(t *testing.T) {
+	s := newTestServerWithRunner(t)
+	body, _ := json.Marshal(map[string]string{"member": "jerry"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+}
+
+func TestCreateRunUnknownMember(t *testing.T) {
+	s := newTestServerWithRunner(t)
+	body, _ := json.Marshal(map[string]string{"member": "ghost", "duty": "lint-fix"})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/runs", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -19,6 +19,7 @@ import (
 
 	"github.com/bupd/night-family/internal/duty"
 	"github.com/bupd/night-family/internal/family"
+	"github.com/bupd/night-family/internal/runner"
 	"github.com/bupd/night-family/internal/schedule"
 	"github.com/bupd/night-family/internal/storage"
 	"github.com/bupd/night-family/internal/version"
@@ -54,6 +55,8 @@ type Config struct {
 	// Storage, when set, enables the persisted /runs, /nights, and
 	// /prs surfaces.
 	Storage *storage.DB
+	// Runner, when set, enables POST /api/v1/runs (dispatch).
+	Runner *runner.Runner
 }
 
 // Server is the running HTTP server.

--- a/internal/ulid/ulid.go
+++ b/internal/ulid/ulid.go
@@ -1,0 +1,46 @@
+// Package ulid generates prefixed ULIDs for night-family's resource
+// IDs (run_…, night_…, pr_…). ULIDs are sortable by time, which lines
+// up with our DB indexes.
+package ulid
+
+import (
+	"math/rand"
+	"sync"
+	"time"
+
+	gulid "github.com/oklog/ulid/v2"
+)
+
+// generator wraps the monotonic reader so concurrent Make calls don't
+// race on the underlying source.
+type generator struct {
+	mu     sync.Mutex
+	reader *gulid.MonotonicEntropy
+}
+
+var defaultGen = newGenerator(time.Now)
+
+func newGenerator(_ func() time.Time) *generator {
+	seed := time.Now().UnixNano()
+	//nolint:gosec // Non-crypto randomness is fine for an opaque ID tiebreaker.
+	r := rand.New(rand.NewSource(seed))
+	return &generator{reader: gulid.Monotonic(r, 0)}
+}
+
+// Make returns "<prefix>_<26-char ULID>" for the given kind, e.g.
+// Make("run") → "run_01HTEST…".
+func Make(prefix string) string {
+	return defaultGen.make(prefix, time.Now())
+}
+
+// MakeAt is Make with an explicit timestamp, for tests.
+func MakeAt(prefix string, t time.Time) string {
+	return defaultGen.make(prefix, t)
+}
+
+func (g *generator) make(prefix string, t time.Time) string {
+	g.mu.Lock()
+	defer g.mu.Unlock()
+	id := gulid.MustNew(gulid.Timestamp(t), g.reader)
+	return prefix + "_" + id.String()
+}


### PR DESCRIPTION
## Summary

Iteration 9: the first time a Run row gets *written*. A POST through the API now threads all the way through the runner and the mock provider, producing a persisted, queryable record.

## What's in the box

- **\`internal/ulid\`** — prefixed-ULID generator around oklog/ulid/v2's monotonic entropy. Produces the \`run_…\`, \`night_…\`, \`pr_…\` IDs the storage schema + spec require.
- **\`internal/provider\`** — \`Provider\` interface (\`Name\` + \`Run(ctx, Request) Result\`) and a deliberate-no-op \`Mock\` adapter. FailMember lets tests exercise the failure path. Real adapters (Claude Code, Codex) slot in behind the same contract in later iterations.
- **\`internal/runner\`** — \`Dispatch(ctx, req)\` orchestrates the full lifecycle: resolve member → insert \`queued\` → flip \`running\` → call provider → flip \`succeeded\`/\`failed\` with token counts and summary/error. Unknown duty types fall back to prompt-only metadata so the custom-duty path keeps working.
- **Server** — \`POST /api/v1/runs\` (body: \`{member, duty, args?}\`) dispatches synchronously and returns \`201 Created\` + the final \`Run\`. Bad body / missing fields / unknown member each surface as \`400\` Problem-Details.
- **\`nfd\`** constructs \`provider.NewMock()\` + \`runner.New(...)\` at startup and logs the provider name.
- **\`nf run start --member X --duty Y\`** — the CLI twin of the new endpoint.
- **Tests** — runner unit tests (success, unknown member, forced failure, cancelled ctx), POST endpoint tests (success, missing fields, unknown member).

## Smoke test (real daemon, ephemeral DB)

\`\`\`
$ nfd -db :memory: &
$ curl -sX POST localhost:7337/api/v1/runs -H 'content-type: application/json' -d '{"member":"jerry","duty":"lint-fix"}'
{"id":"run_01KPKWGG5T0YYAGNDDVFRVQGWN","member":"jerry","duty":"lint-fix","status":"succeeded","tokens_in":1234,"tokens_out":567,"summary":"[mock] jerry/lint-fix completed — no real changes made. …"}
$ curl -s localhost:7337/api/v1/runs | jq '.items[0].id'
"run_01KPKWGG5T0YYAGNDDVFRVQGWN"
\`\`\`

## Design notes

- **Dispatch is synchronous for v1.** Real providers will need async + 202 Accepted + log streaming; that's iteration 10+.
- **Token counts are reported by the provider**, not inferred, so real Claude Code runs can surface truth directly.
- **Unknown duty → prompt-only fallback** rather than rejection. Keeps custom-prompt duties legal end-to-end.

## Dependency delta

\`github.com/oklog/ulid/v2 v2.1.1\`.

## Test plan

- [x] \`task check\` passes
- [x] Runner unit tests cover success, unknown member, forced failure, cancelled ctx
- [x] POST /api/v1/runs tests cover success + the 400 branches
- [x] End-to-end smoke against a live daemon works (see above)
- [ ] CI green

## Out of scope (iteration 10)

- Async + 202 + SSE log streaming
- POST /api/v1/nights/trigger to run a whole planned night
- Scheduler loop (cron-ish, tied to the window)
- Real Claude Code provider

cc @coderabbitai @cubic-dev-ai — please eye the runner lifecycle transitions (queued → running → terminal), the Dispatch error-vs-Run semantics, and whether the POST endpoint should really return 201 synchronously or flip to 202 now. Also: Mock's interface shape — is it right before real adapters land?

🤖 Generated with [Claude Code](https://claude.com/claude-code)