### PR TITLE
feat(nights): trigger a full night via POST /api/v1/nights/trigger

### DIFF
--- a/cmd/nf/night.go
+++ b/cmd/nf/night.go
@@ -6,13 +6,91 @@ import (
 	"fmt"
 	"net/url"
 	"os"
+	"strings"
 	"text/tabwriter"
 )
+
+func nightTrigger(args []string) {
+	fs := flag.NewFlagSet("night trigger", flag.ExitOnError)
+	members := fs.String("only-members", "", "comma-separated member names to include (default: all)")
+	duties := fs.String("only-duties", "", "comma-separated duty types to include (default: all)")
+	budget := fs.Int("budget", 0, "token budget ceiling (0 = unlimited)")
+	dryRun := fs.Bool("dry-run", false, "plan the night but do not dispatch runs")
+	_ = fs.Parse(args)
+
+	body := map[string]any{}
+	if *members != "" {
+		body["only_members"] = strings.Split(*members, ",")
+	}
+	if *duties != "" {
+		body["only_duties"] = strings.Split(*duties, ",")
+	}
+	if *budget > 0 {
+		body["budget"] = *budget
+	}
+	if *dryRun {
+		body["dry_run"] = true
+	}
+	raw, _ := json.Marshal(body)
+	var res map[string]any
+	if err := apiPost("/api/v1/nights/trigger", raw, &res); err != nil {
+		fmt.Fprintln(os.Stderr, "nf:", err)
+		os.Exit(1)
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(res)
+}
+
+func nightList(_ []string) {
+	var body map[string]any
+	if err := apiGet("/api/v1/nights", &body); err != nil {
+		fmt.Fprintln(os.Stderr, "nf:", err)
+		os.Exit(1)
+	}
+	items, _ := body["items"].([]any)
+	if len(items) == 0 {
+		fmt.Println("(no nights)")
+		return
+	}
+	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
+	fmt.Fprintln(tw, "ID\tSTARTED\tFINISHED\tSUMMARY")
+	for _, it := range items {
+		m := it.(map[string]any)
+		started, _ := m["started_at"].(string)
+		finished, _ := m["finished_at"].(string)
+		if finished == "" {
+			finished = "—"
+		}
+		summary, _ := m["summary"].(string)
+		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", m["id"], started, finished, summary)
+	}
+	_ = tw.Flush()
+}
+
+func nightShow(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "nf night show: <id> required")
+		os.Exit(2)
+	}
+	var body map[string]any
+	if err := apiGet("/api/v1/nights/"+args[0], &body); err != nil {
+		fmt.Fprintln(os.Stderr, "nf:", err)
+		os.Exit(1)
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(body)
+}
 
 const nightUsage = `nf night — inspect or trigger nightly plans
 
 Usage:
-  nf night preview [--budget N] [--json]    Show what would run if a night started now
+  nf night preview [--budget N] [--json]                          Show what would run if a night started now
+  nf night trigger [--only-members X,Y] [--only-duties A,B] [--dry-run] [--budget N]
+                                                                  Dispatch a night synchronously via the daemon's provider
+  nf night list                                                   List past nights
+  nf night show <id>                                              Show one night
 `
 
 type nightSlot struct {
@@ -49,6 +127,12 @@ func nightCmd(args []string) {
 	switch args[0] {
 	case "preview":
 		nightPreview(args[1:])
+	case "trigger":
+		nightTrigger(args[1:])
+	case "list":
+		nightList(args[1:])
+	case "show":
+		nightShow(args[1:])
 	case "help", "-h", "--help":
 		fmt.Print(nightUsage)
 	default:

--- a/internal/runner/night.go
+++ b/internal/runner/night.go
@@ -1,0 +1,129 @@
+package runner
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"time"
+
+	"github.com/bupd/night-family/internal/planner"
+	"github.com/bupd/night-family/internal/schedule"
+	"github.com/bupd/night-family/internal/storage"
+	"github.com/bupd/night-family/internal/ulid"
+)
+
+// NightOptions shape the TriggerNight call.
+type NightOptions struct {
+	// OnlyMembers/OnlyDuties, when non-empty, restrict the plan to
+	// those filters.
+	OnlyMembers []string
+	OnlyDuties  []string
+	// DryRun plans but does not dispatch runs.
+	DryRun bool
+	// Budget caps total token spend across the night. Zero = no cap.
+	Budget int
+}
+
+// NightResult is what TriggerNight returns. Errors inside individual
+// runs do not stop the night — they're recorded against each Run.
+type NightResult struct {
+	ID      string        `json:"id"`
+	Runs    []storage.Run `json:"runs"`
+	Plan    planner.Plan  `json:"plan"`
+	Skipped int           `json:"skipped"`
+}
+
+// TriggerNight plans + dispatches a night. v1 runs slots sequentially
+// so token budgets are respected deterministically.
+func (r *Runner) TriggerNight(ctx context.Context, sched *schedule.Schedule, opts NightOptions) (NightResult, error) {
+	plan, err := planner.Input{
+		Family:       r.deps.Family,
+		Duties:       r.deps.Duties,
+		Schedule:     sched,
+		Now:          time.Now(),
+		BudgetTokens: opts.Budget,
+	}.Plan()
+	if err != nil {
+		return NightResult{}, fmt.Errorf("runner: plan: %w", err)
+	}
+	plan.Slots = filterSlots(plan.Slots, opts.OnlyMembers, opts.OnlyDuties)
+
+	nightID := ulid.Make("night")
+	started := time.Now().UTC()
+
+	planJSON, _ := json.Marshal(plan)
+	if err := r.deps.Storage.InsertNight(ctx, storage.Night{
+		ID:        nightID,
+		StartedAt: started,
+		PlanJSON:  string(planJSON),
+	}); err != nil {
+		return NightResult{}, fmt.Errorf("runner: insert night: %w", err)
+	}
+
+	var runs []storage.Run
+	if !opts.DryRun {
+		for _, slot := range plan.Slots {
+			select {
+			case <-ctx.Done():
+				r.deps.Logger.Warn("night cancelled mid-dispatch", "night", nightID)
+				goto finish
+			default:
+			}
+			nightRef := nightID
+			run, err := r.Dispatch(ctx, DispatchRequest{
+				Member:  slot.Member,
+				Duty:    slot.Duty,
+				NightID: &nightRef,
+			})
+			if err != nil {
+				r.deps.Logger.Error("dispatch failed", "night", nightID, "err", err)
+				continue
+			}
+			runs = append(runs, run)
+		}
+	}
+finish:
+	summary := fmt.Sprintf("night %s: %d runs dispatched (%d skipped at plan time)",
+		nightID, len(runs), len(plan.Skipped))
+	_ = r.deps.Storage.FinishNight(ctx, nightID, time.Now().UTC(), summary)
+	r.deps.Logger.Info("night done", "night", nightID, "runs", len(runs))
+
+	return NightResult{
+		ID:      nightID,
+		Runs:    runs,
+		Plan:    plan,
+		Skipped: len(plan.Skipped),
+	}, nil
+}
+
+// filterSlots returns only slots that match the allow-lists (or all
+// slots when both lists are empty).
+func filterSlots(in []planner.Slot, onlyMembers, onlyDuties []string) []planner.Slot {
+	if len(onlyMembers) == 0 && len(onlyDuties) == 0 {
+		return in
+	}
+	mem := toSet(onlyMembers)
+	dut := toSet(onlyDuties)
+	out := in[:0]
+	for _, s := range in {
+		if len(mem) > 0 && !mem[s.Member] {
+			continue
+		}
+		if len(dut) > 0 && !dut[s.Duty] {
+			continue
+		}
+		out = append(out, s)
+	}
+	return out
+}
+
+func toSet(xs []string) map[string]bool {
+	if len(xs) == 0 {
+		return nil
+	}
+	m := make(map[string]bool, len(xs))
+	for _, x := range xs {
+		m[x] = true
+	}
+	return m
+}

--- a/internal/server/nights.go
+++ b/internal/server/nights.go
@@ -1,0 +1,85 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/bupd/night-family/internal/runner"
+	"github.com/bupd/night-family/internal/storage"
+)
+
+func (s *Server) nightsRoutes(mux *http.ServeMux) {
+	if s.cfg.Storage == nil {
+		return
+	}
+	mux.HandleFunc("GET /api/v1/nights", s.listNights)
+	mux.HandleFunc("GET /api/v1/nights/{id}", s.getNight)
+	if s.cfg.Runner != nil && s.cfg.Schedule != nil {
+		mux.HandleFunc("POST /api/v1/nights/trigger", s.triggerNight)
+	}
+}
+
+func (s *Server) listNights(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+	nights, err := s.cfg.Storage.ListNights(ctx, 100)
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "db_error", err.Error(), r.URL.Path)
+		return
+	}
+	if nights == nil {
+		nights = []storage.Night{}
+	}
+	writeJSON(w, http.StatusOK, map[string]any{"items": nights})
+}
+
+func (s *Server) getNight(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+	id := r.PathValue("id")
+	night, err := s.cfg.Storage.GetNight(ctx, id)
+	if errors.Is(err, storage.ErrNotFound) {
+		writeProblem(w, http.StatusNotFound, "not_found", "Night not found", r.URL.Path)
+		return
+	}
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "db_error", err.Error(), r.URL.Path)
+		return
+	}
+	writeJSON(w, http.StatusOK, night)
+}
+
+type triggerNightRequest struct {
+	OnlyMembers []string `json:"only_members,omitempty"`
+	OnlyDuties  []string `json:"only_duties,omitempty"`
+	Budget      int      `json:"budget,omitempty"`
+	DryRun      bool     `json:"dry_run,omitempty"`
+}
+
+func (s *Server) triggerNight(w http.ResponseWriter, r *http.Request) {
+	var req triggerNightRequest
+	if r.ContentLength > 0 {
+		if err := json.NewDecoder(r.Body).Decode(&req); err != nil {
+			writeProblem(w, http.StatusBadRequest, "bad_request", "invalid JSON body: "+err.Error(), r.URL.Path)
+			return
+		}
+	}
+	// Give the night a generous ceiling; individual mock runs are
+	// ~20ms each, so a full plan finishes well inside this.
+	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	defer cancel()
+	res, err := s.cfg.Runner.TriggerNight(ctx, s.cfg.Schedule, runner.NightOptions{
+		OnlyMembers: req.OnlyMembers,
+		OnlyDuties:  req.OnlyDuties,
+		Budget:      req.Budget,
+		DryRun:      req.DryRun,
+	})
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "trigger_failed", err.Error(), r.URL.Path)
+		return
+	}
+	writeJSON(w, http.StatusAccepted, res)
+}

--- a/internal/server/nights_test.go
+++ b/internal/server/nights_test.go
@@ -1,0 +1,120 @@
+package server
+
+import (
+	"bytes"
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bupd/night-family/internal/duty"
+	"github.com/bupd/night-family/internal/family"
+	"github.com/bupd/night-family/internal/provider"
+	"github.com/bupd/night-family/internal/runner"
+	"github.com/bupd/night-family/internal/schedule"
+	"github.com/bupd/night-family/internal/storage"
+)
+
+func newTestServerWithNight(t *testing.T) *Server {
+	t.Helper()
+	fam := family.NewStore()
+	defaults, _ := family.LoadDefaults()
+	fam.Seed(defaults)
+	db, err := storage.Open(context.Background(), ":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	logger := slog.New(slog.NewTextHandler(io.Discard, nil))
+	rn, err := runner.New(runner.Deps{
+		Family:   fam,
+		Duties:   duty.NewBuiltinRegistry(),
+		Storage:  db,
+		Provider: provider.NewMock(),
+		Logger:   logger,
+	})
+	if err != nil {
+		t.Fatalf("runner.New: %v", err)
+	}
+	sched := schedule.Default()
+	s, err := New(Config{
+		Addr:     "127.0.0.1:0",
+		Logger:   logger,
+		Family:   fam,
+		Duties:   duty.NewBuiltinRegistry(),
+		Storage:  db,
+		Runner:   rn,
+		Schedule: &sched,
+	})
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+	return s
+}
+
+func TestTriggerNightOnlyOneMember(t *testing.T) {
+	s := newTestServerWithNight(t)
+	body, _ := json.Marshal(map[string]any{"only_members": []string{"jerry"}})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/nights/trigger", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	var res map[string]any
+	if err := json.Unmarshal(rr.Body.Bytes(), &res); err != nil {
+		t.Fatalf("decode: %v", err)
+	}
+	runs, _ := res["runs"].([]any)
+	if len(runs) == 0 {
+		t.Fatalf("no runs in night result")
+	}
+	for _, r := range runs {
+		m := r.(map[string]any)
+		if m["member"] != "jerry" {
+			t.Errorf("run member = %v, want jerry", m["member"])
+		}
+	}
+}
+
+func TestTriggerNightDryRunPersistsNightButNoRuns(t *testing.T) {
+	s := newTestServerWithNight(t)
+	body, _ := json.Marshal(map[string]any{"dry_run": true})
+	req := httptest.NewRequest(http.MethodPost, "/api/v1/nights/trigger", bytes.NewReader(body))
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusAccepted {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	var res map[string]any
+	_ = json.Unmarshal(rr.Body.Bytes(), &res)
+	runs, _ := res["runs"].([]any)
+	if len(runs) != 0 {
+		t.Errorf("dry_run produced %d runs, want 0", len(runs))
+	}
+
+	listReq := httptest.NewRequest(http.MethodGet, "/api/v1/nights", nil)
+	listRR := httptest.NewRecorder()
+	s.routes().ServeHTTP(listRR, listReq)
+	var listBody map[string]any
+	_ = json.Unmarshal(listRR.Body.Bytes(), &listBody)
+	items, _ := listBody["items"].([]any)
+	if len(items) != 1 {
+		t.Errorf("nights list = %d items, want 1", len(items))
+	}
+}
+
+func TestGetNightNotFound(t *testing.T) {
+	s := newTestServerWithNight(t)
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/nights/night_missing", nil)
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rr.Code)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -126,6 +126,7 @@ func (s *Server) routes() http.Handler {
 	s.scheduleRoutes(mux)
 	s.plannerRoutes(mux)
 	s.runsRoutes(mux)
+	s.nightsRoutes(mux)
 	mux.HandleFunc("GET /", s.index)
 
 	if staticSub, err := fs.Sub(s.web, "static"); err == nil {

--- a/internal/storage/nights.go
+++ b/internal/storage/nights.go
@@ -1,0 +1,117 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"fmt"
+	"time"
+)
+
+// Night is the persisted representation of one scheduled (or manually
+// triggered) window.
+type Night struct {
+	ID         string     `json:"id"`
+	StartedAt  time.Time  `json:"started_at"`
+	FinishedAt *time.Time `json:"finished_at,omitempty"`
+	PlanJSON   string     `json:"plan_json,omitempty"`
+	Summary    *string    `json:"summary,omitempty"`
+}
+
+// InsertNight persists a new Night. The caller owns ID generation.
+func (db *DB) InsertNight(ctx context.Context, n Night) error {
+	if n.ID == "" {
+		return errors.New("storage: InsertNight: id required")
+	}
+	if n.StartedAt.IsZero() {
+		return errors.New("storage: InsertNight: started_at required")
+	}
+	if n.PlanJSON == "" {
+		n.PlanJSON = "{}"
+	}
+	_, err := db.raw.ExecContext(ctx, `
+		INSERT INTO nights(id, started_at, finished_at, plan_json, summary)
+		VALUES (?, ?, ?, ?, ?)`,
+		n.ID,
+		n.StartedAt.UTC().Format(time.RFC3339Nano),
+		nullableTime(n.FinishedAt),
+		n.PlanJSON,
+		nullableStr(n.Summary),
+	)
+	return err
+}
+
+// FinishNight stamps finished_at and a summary on a Night.
+func (db *DB) FinishNight(ctx context.Context, id string, finishedAt time.Time, summary string) error {
+	_, err := db.raw.ExecContext(ctx, `
+		UPDATE nights SET
+			finished_at = ?,
+			summary     = ?
+		WHERE id = ?`,
+		finishedAt.UTC().Format(time.RFC3339Nano),
+		summary,
+		id,
+	)
+	return err
+}
+
+// GetNight returns one Night or ErrNotFound.
+func (db *DB) GetNight(ctx context.Context, id string) (Night, error) {
+	row := db.raw.QueryRowContext(ctx, `
+		SELECT id, started_at, finished_at, plan_json, summary
+		FROM nights WHERE id = ?`, id)
+	return scanNight(row)
+}
+
+// ListNights returns nights ordered by started_at desc.
+func (db *DB) ListNights(ctx context.Context, limit int) ([]Night, error) {
+	if limit <= 0 || limit > 500 {
+		limit = 50
+	}
+	rows, err := db.raw.QueryContext(ctx, fmt.Sprintf(`
+		SELECT id, started_at, finished_at, plan_json, summary
+		FROM nights ORDER BY started_at DESC LIMIT %d`, limit))
+	if err != nil {
+		return nil, err
+	}
+	defer rows.Close()
+	var out []Night
+	for rows.Next() {
+		n, err := scanNight(rows)
+		if err != nil {
+			return nil, err
+		}
+		out = append(out, n)
+	}
+	return out, rows.Err()
+}
+
+func scanNight(row rowScanner) (Night, error) {
+	var n Night
+	var (
+		finishedAt, summary sql.NullString
+		startedAt           string
+		planJSON            string
+	)
+	err := row.Scan(&n.ID, &startedAt, &finishedAt, &planJSON, &summary)
+	if errors.Is(err, sql.ErrNoRows) {
+		return Night{}, ErrNotFound
+	}
+	if err != nil {
+		return Night{}, err
+	}
+	if t, perr := time.Parse(time.RFC3339Nano, startedAt); perr == nil {
+		n.StartedAt = t
+	}
+	if finishedAt.Valid {
+		if t, perr := time.Parse(time.RFC3339Nano, finishedAt.String); perr == nil {
+			n.FinishedAt = &t
+		}
+	}
+	n.PlanJSON = planJSON
+	if summary.Valid {
+		s := summary.String
+		n.Summary = &s
+	}
+	return n, nil
+}

--- a/internal/storage/nights_test.go
+++ b/internal/storage/nights_test.go
@@ -1,0 +1,56 @@
+package storage
+
+import (
+	"context"
+	"errors"
+	"testing"
+	"time"
+)
+
+func TestInsertGetListNight(t *testing.T) {
+	db := openMem(t)
+	ctx := context.Background()
+	started := time.Date(2026, 4, 17, 22, 0, 0, 0, time.UTC)
+
+	n := Night{
+		ID:        "night_01HTEST000000000000000AAA",
+		StartedAt: started,
+		PlanJSON:  `{"slots":[{"member":"rick","duty":"vuln-scan"}]}`,
+	}
+	if err := db.InsertNight(ctx, n); err != nil {
+		t.Fatalf("InsertNight: %v", err)
+	}
+	got, err := db.GetNight(ctx, n.ID)
+	if err != nil {
+		t.Fatalf("GetNight: %v", err)
+	}
+	if !got.StartedAt.Equal(started) {
+		t.Errorf("StartedAt mismatch")
+	}
+	if got.PlanJSON != n.PlanJSON {
+		t.Errorf("PlanJSON mismatch")
+	}
+	if _, err := db.GetNight(ctx, "night_missing"); !errors.Is(err, ErrNotFound) {
+		t.Errorf("Get(missing) err = %v", err)
+	}
+
+	finished := started.Add(time.Hour)
+	if err := db.FinishNight(ctx, n.ID, finished, "done, 1 PR opened"); err != nil {
+		t.Fatalf("FinishNight: %v", err)
+	}
+	got, _ = db.GetNight(ctx, n.ID)
+	if got.FinishedAt == nil || !got.FinishedAt.Equal(finished) {
+		t.Errorf("FinishedAt = %v", got.FinishedAt)
+	}
+	if got.Summary == nil || *got.Summary != "done, 1 PR opened" {
+		t.Errorf("Summary = %v", got.Summary)
+	}
+
+	list, err := db.ListNights(ctx, 10)
+	if err != nil {
+		t.Fatalf("ListNights: %v", err)
+	}
+	if len(list) != 1 || list[0].ID != n.ID {
+		t.Errorf("list = %+v", list)
+	}
+}


### PR DESCRIPTION
## Summary

Iteration 10: one POST kicks off a full night. The planner + runner chain is now wrapped by a night orchestration step that inserts a Night row, dispatches every plan slot, and finalises with a summary — all persisted.

## What's in the box

- **\`internal/storage\`** — \`Night\` type + \`InsertNight\` / \`FinishNight\` / \`GetNight\` / \`ListNights\`.
- **\`runner.TriggerNight\`** — plans from (family, duties, schedule, budget) → filters by \`only_members\` / \`only_duties\` → inserts a Night carrying the plan JSON → dispatches each slot sequentially (tagged with \`night_id\`) → \`FinishNight\` with a summary. Honours \`dry_run\` (persists the night, skips dispatches) and mid-flight ctx cancellation (still finalises with whatever ran).
- **Server** — \`GET /api/v1/nights\`, \`GET /api/v1/nights/{id}\`, \`POST /api/v1/nights/trigger\` (only wired when Runner + Schedule are present). \`/trigger\` returns 202 Accepted with \`{ id, runs, plan, skipped }\`.
- **\`nf night trigger\` / \`night list\` / \`night show\`** — the CLI twin.
- **Tests** — \`only_members\` filter, \`dry_run\` (night persisted, 0 runs), 404 for unknown night id, plus the storage round-trip.

## Smoke test (one command, zero setup)

\`\`\`
$ nfd -db :memory: &
$ curl -s -XPOST localhost:7337/api/v1/nights/trigger -H 'content-type: application/json' -d '{}' | jq '.runs | length'
12
$ curl -s localhost:7337/api/v1/runs | jq '.items | length'
12
$ curl -s localhost:7337/api/v1/nights | jq '.items[0].summary'
"night night_01KPKWRZ78P5HH2CDF6T8WH6YA: 12 runs dispatched (2 skipped at plan time)"
\`\`\`

Default seven-member roster + 18-duty catalogue → 12 dispatched slots + 2 skipped (cap-hit). Each run succeeds via the mock provider and is fully persisted.

## Design notes

- **Synchronous for now** — the handler blocks until the night finishes. That's OK at mock speeds (~250ms total); once the real Claude adapter lands we'll flip to async + SSE status streaming.
- **Night failure != run failure** — individual run errors don't abort the night; each failing run is logged and the night continues. TriggerNight only returns an error when the *plan* itself can't be built (schedule invalid, deps missing).
- **Plan is persisted as JSON** on the Night row so post-hoc debugging / dashboards can reconstruct exactly what was planned (including the skipped list, token reservations, window times).

## Test plan

- [x] \`task check\` passes
- [x] Night is stored + finished with a summary
- [x] \`only_members\` / \`dry_run\` behave correctly
- [x] End-to-end smoke against a live daemon produces 12 runs
- [ ] CI green

## Out of scope (next iteration)

- The actual **scheduler loop** that triggers nights automatically inside the 22:00→05:00 window.
- SSE live status on \`POST /nights/trigger\` so the UI can stream progress.
- Git orchestrator — branches + PRs with reviewer tagging (iteration 11).
- Real Claude Code provider.

cc @coderabbitai @cubic-dev-ai — please poke at: the sync-vs-async choice for \`/trigger\` (202 Accepted with the full result is unusual), the individual-run-failure-doesn't-fail-night policy, and the plan-as-JSON persistence shape.

🤖 Generated with [Claude Code](https://claude.com/claude-code)