### PR TITLE
feat(scheduler): --auto-trigger fires a night at window open

### DIFF
--- a/cmd/nfd/main.go
+++ b/cmd/nfd/main.go
@@ -23,6 +23,7 @@ import (
 	"github.com/bupd/night-family/internal/provider"
 	"github.com/bupd/night-family/internal/runner"
 	"github.com/bupd/night-family/internal/schedule"
+	nfscheduler "github.com/bupd/night-family/internal/scheduler"
 	"github.com/bupd/night-family/internal/server"
 	"github.com/bupd/night-family/internal/storage"
 )
@@ -37,6 +38,7 @@ func main() {
 	signOff := flag.Bool("signoff", true, "add a DCO Signed-off-by trailer to commits")
 	skipPush := flag.Bool("skip-push", false, "orchestrator stops after local commit (does not push)")
 	skipPR := flag.Bool("skip-pr", false, "orchestrator stops after push (does not open a PR)")
+	autoTrigger := flag.Bool("auto-trigger", false, "fire a night automatically when the schedule window opens")
 	flag.Parse()
 
 	logger := newLogger(*logLevel)
@@ -116,6 +118,20 @@ func main() {
 	})
 	if err != nil {
 		fatal(logger, "server init: %v", err)
+	}
+
+	loopCtx, loopCancel := context.WithCancel(context.Background())
+	defer loopCancel()
+	if *autoTrigger {
+		loop := nfscheduler.New(nfscheduler.Options{
+			Schedule: &sched,
+			Runner:   run,
+			Logger:   logger,
+		})
+		loop.Start(loopCtx)
+		logger.Info("scheduler loop running", "window", sched.WindowStart+"-"+sched.WindowEnd)
+	} else {
+		logger.Info("auto-trigger disabled (pass --auto-trigger to enable)")
 	}
 
 	errCh := make(chan error, 1)

--- a/internal/scheduler/loop.go
+++ b/internal/scheduler/loop.go
@@ -1,0 +1,120 @@
+// Package scheduler is the background loop that fires a night when
+// the configured window opens.
+//
+// v1 is a tick loop: every tick, check whether we're inside the
+// window and whether we've already run a night for this window. If
+// both answers line up, trigger. That's it — no cron, no overlap, no
+// catching up on missed nights.
+//
+// The heavy lifting (plan, dispatch, record) lives in runner.TriggerNight.
+// This package only owns the "when to fire" decision.
+package scheduler
+
+import (
+	"context"
+	"log/slog"
+	"sync"
+	"time"
+
+	"github.com/bupd/night-family/internal/runner"
+	"github.com/bupd/night-family/internal/schedule"
+)
+
+// Options configure a Loop.
+type Options struct {
+	Schedule *schedule.Schedule
+	Runner   *runner.Runner
+	Logger   *slog.Logger
+	// Tick is the poll interval. 1m is plenty for the nightly cadence;
+	// tests override to nanoseconds.
+	Tick time.Duration
+	// Clock, when set, replaces time.Now for testing.
+	Clock func() time.Time
+	// TriggerOpts is passed through to runner.TriggerNight on every
+	// auto-fire. Useful for e.g. setting a default budget.
+	TriggerOpts runner.NightOptions
+}
+
+// Loop drives a ticker; it fires TriggerNight at most once per window
+// start. Call Start to spawn the goroutine; it stops when ctx is
+// cancelled.
+type Loop struct {
+	opts     Options
+	mu       sync.Mutex
+	lastFire time.Time
+	running  bool
+}
+
+// New returns a Loop ready to be Start()-ed.
+func New(opts Options) *Loop {
+	if opts.Tick == 0 {
+		opts.Tick = time.Minute
+	}
+	if opts.Clock == nil {
+		opts.Clock = time.Now
+	}
+	return &Loop{opts: opts}
+}
+
+// Start spawns the loop. Safe to call twice — second call is a no-op.
+func (l *Loop) Start(ctx context.Context) {
+	l.mu.Lock()
+	if l.running {
+		l.mu.Unlock()
+		return
+	}
+	l.running = true
+	l.mu.Unlock()
+	go l.run(ctx)
+}
+
+// LastFire returns the wall time of the most recent auto-fire, or
+// zero if nothing has fired yet.
+func (l *Loop) LastFire() time.Time {
+	l.mu.Lock()
+	defer l.mu.Unlock()
+	return l.lastFire
+}
+
+func (l *Loop) run(ctx context.Context) {
+	t := time.NewTicker(l.opts.Tick)
+	defer t.Stop()
+	l.tick(ctx)
+	for {
+		select {
+		case <-ctx.Done():
+			l.opts.Logger.Info("scheduler stopped")
+			return
+		case <-t.C:
+			l.tick(ctx)
+		}
+	}
+}
+
+func (l *Loop) tick(ctx context.Context) {
+	now := l.opts.Clock()
+	start, _, err := l.opts.Schedule.Next(now)
+	if err != nil {
+		l.opts.Logger.Warn("scheduler: schedule invalid", "err", err)
+		return
+	}
+	if !l.opts.Schedule.IsInWindow(now) {
+		return
+	}
+	l.mu.Lock()
+	already := !l.lastFire.Before(start)
+	l.mu.Unlock()
+	if already {
+		return
+	}
+	l.opts.Logger.Info("scheduler: firing night", "window_start", start)
+	res, err := l.opts.Runner.TriggerNight(ctx, l.opts.Schedule, l.opts.TriggerOpts)
+	if err != nil {
+		l.opts.Logger.Error("scheduler: TriggerNight failed", "err", err)
+		return
+	}
+	l.mu.Lock()
+	l.lastFire = now
+	l.mu.Unlock()
+	l.opts.Logger.Info("scheduler: night fired", "night", res.ID, "runs", len(res.Runs))
+}

--- a/internal/scheduler/loop_test.go
+++ b/internal/scheduler/loop_test.go
@@ -1,0 +1,95 @@
+package scheduler
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"sync/atomic"
+	"testing"
+	"time"
+
+	"github.com/bupd/night-family/internal/duty"
+	"github.com/bupd/night-family/internal/family"
+	"github.com/bupd/night-family/internal/provider"
+	"github.com/bupd/night-family/internal/runner"
+	"github.com/bupd/night-family/internal/schedule"
+	"github.com/bupd/night-family/internal/storage"
+)
+
+func TestTickInsideWindowFires(t *testing.T) {
+	loc, _ := time.LoadLocation("Europe/Berlin")
+	sched := schedule.Schedule{WindowStart: "22:00", WindowEnd: "05:00", TimeZone: "Europe/Berlin"}
+	// pinned clock: 23:00 (inside window)
+	now := time.Date(2026, 4, 17, 23, 0, 0, 0, loc)
+	var fires int32
+	wrapped := wrapCountRunner(t, &fires)
+
+	l := New(Options{
+		Schedule: &sched,
+		Runner:   wrapped,
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Tick:     time.Nanosecond,
+		Clock:    func() time.Time { return now },
+	})
+	// Call tick twice — second should be a no-op because we've already fired for this window.
+	l.tick(context.Background())
+	l.tick(context.Background())
+	if got := atomic.LoadInt32(&fires); got != 1 {
+		t.Fatalf("fires = %d, want 1", got)
+	}
+}
+
+func TestTickOutsideWindowDoesNotFire(t *testing.T) {
+	loc, _ := time.LoadLocation("Europe/Berlin")
+	sched := schedule.Schedule{WindowStart: "22:00", WindowEnd: "05:00", TimeZone: "Europe/Berlin"}
+	// pinned clock: 12:00 (way outside)
+	now := time.Date(2026, 4, 17, 12, 0, 0, 0, loc)
+	var fires int32
+	wrapped := wrapCountRunner(t, &fires)
+	l := New(Options{
+		Schedule: &sched,
+		Runner:   wrapped,
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Tick:     time.Nanosecond,
+		Clock:    func() time.Time { return now },
+	})
+	l.tick(context.Background())
+	if got := atomic.LoadInt32(&fires); got != 0 {
+		t.Fatalf("fires = %d, want 0", got)
+	}
+}
+
+// wrapCountRunner returns a Runner that increments *n every time
+// TriggerNight is called. Since TriggerNight isn't an interface we
+// wrap the real Runner and swap its provider for a fast mock; the
+// counter sits in front of the provider via a helper adapter below.
+func wrapCountRunner(t *testing.T, n *int32) *runner.Runner {
+	t.Helper()
+	fam := family.NewStore()
+	fam.Seed([]family.Member{{
+		Name: "rick", Role: "r", SystemPrompt: "p",
+		Duties: []family.Duty{{Type: "lint-fix", Interval: "24h", Priority: family.PriorityHigh}},
+	}})
+	db, _ := storage.Open(context.Background(), ":memory:")
+	t.Cleanup(func() { _ = db.Close() })
+	r, _ := runner.New(runner.Deps{
+		Family:   fam,
+		Duties:   duty.NewBuiltinRegistry(),
+		Storage:  db,
+		Provider: &countProvider{n: n},
+		Logger:   slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	return r
+}
+
+// countProvider is a tiny Provider that increments a shared counter
+// on every Run call — used as a proxy for "TriggerNight fired at
+// least one dispatch".
+type countProvider struct{ n *int32 }
+
+func (c *countProvider) Name() string { return "count" }
+
+func (c *countProvider) Run(ctx context.Context, req provider.Request) (*provider.Result, error) {
+	atomic.AddInt32(c.n, 1)
+	return &provider.Result{Summary: "ok"}, nil
+}


### PR DESCRIPTION
## Summary

Iteration 14: night-family now *wakes up*. A simple tick loop notices when the window opens and fires a night automatically. Wire this with \`--repo\` and a real provider and the PRs-by-morning loop runs end-to-end.

## What's in the box

- **\`internal/scheduler.Loop\`** — pollable, cancellable, clock-injected.
  - Every Tick (default 1m) checks \`Schedule.IsInWindow(now)\`.
  - Fires \`runner.TriggerNight\` once per window start (\`lastFire\` tracked in a mutex).
  - Out-of-window ticks are no-ops.
- **\`nfd --auto-trigger\`** — off by default; when set, spawns the loop at daemon start.
- **Tests** — pinned clock: in-window tick fires once, second tick is a no-op, out-of-window tick never fires.

## Why deliberately simple

- **No cron.** The window is the whole expressivity we need (22:00→05:00 or whatever the user sets). Cron collapses into two fields.
- **No missed-window catch-up.** If the laptop was off during the window, the night is gone. Re-running yesterday's night at 3pm is worse than running nothing.
- **No overlapping nights.** TriggerNight is synchronous today; the loop can't start a second one while the first is in flight.

All of those are reversible when we have a reason.

## Demo recipe

\`\`\`
nfd \\
  --db :memory: \\
  --repo /path/to/playground \\
  --reviewers coderabbitai,cubic-dev-ai \\
  --auto-trigger

# At 22:00 local time, a PR per plan slot lands in /path/to/playground.
\`\`\`

## Test plan

- [x] \`task check\` passes
- [x] tick() + pinned clock: fires once per window, second call is no-op
- [x] tick() outside the window: zero fires
- [x] nfd starts with --auto-trigger and logs "scheduler loop running"
- [ ] CI green

## Follow-ups

- Retry / backoff if TriggerNight fails (v1 just logs and waits for the next tick).
- Telemetry: a /api/v1/scheduler endpoint showing lastFire + next predicted fire.
- SIGHUP to re-read config / schedule changes without a restart.

cc @coderabbitai @cubic-dev-ai — please review: the "fire at most once per window" invariant, the lock-ordering around lastFire, and whether exposing Tick/Clock through Options is over-engineered or right-sized.

🤖 Generated with [Claude Code](https://claude.com/claude-code)