### PR TITLE
feat(provider): add Claude adapter (spawns 'claude --print')

### DIFF
--- a/cmd/nfd/main.go
+++ b/cmd/nfd/main.go
@@ -39,6 +39,9 @@ func main() {
 	skipPush := flag.Bool("skip-push", false, "orchestrator stops after local commit (does not push)")
 	skipPR := flag.Bool("skip-pr", false, "orchestrator stops after push (does not open a PR)")
 	autoTrigger := flag.Bool("auto-trigger", false, "fire a night automatically when the schedule window opens")
+	providerName := flag.String("provider", "mock", "provider to dispatch through: 'mock' or 'claude'")
+	claudeBin := flag.String("claude-bin", "claude", "claude CLI binary path (used when --provider=claude)")
+	claudeArgs := flag.String("claude-args", "", "extra space-separated args to pass to the claude binary")
 	flag.Parse()
 
 	logger := newLogger(*logLevel)
@@ -67,7 +70,10 @@ func main() {
 	}
 	defer db.Close()
 
-	prov := provider.NewMock()
+	prov, err := buildProvider(*providerName, *claudeBin, *claudeArgs)
+	if err != nil {
+		fatal(logger, "provider: %v", err)
+	}
 	logger.Info("provider", "name", prov.Name())
 
 	var orch *gitops.Orchestrator
@@ -185,6 +191,26 @@ func openStorage(ctx context.Context, explicit string, logger *slog.Logger) (*st
 	}
 	logger.Info("storage", "dsn", dsn)
 	return storage.Open(ctx, dsn)
+}
+
+// buildProvider resolves the --provider flag into a provider.Provider
+// instance. Unknown names fail loudly so users catch typos at boot.
+func buildProvider(name, bin, extraArgs string) (provider.Provider, error) {
+	switch name {
+	case "", "mock":
+		return provider.NewMock(), nil
+	case "claude":
+		c := provider.NewClaude()
+		if bin != "" {
+			c.Bin = bin
+		}
+		if extraArgs != "" {
+			c.ExtraArgs = strings.Fields(extraArgs)
+		}
+		return c, nil
+	default:
+		return nil, fmt.Errorf("unknown provider %q (valid: mock, claude)", name)
+	}
 }
 
 func fatal(logger *slog.Logger, format string, args ...any) {

--- a/internal/provider/claude.go
+++ b/internal/provider/claude.go
@@ -1,0 +1,130 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Claude invokes `claude` in print mode (`claude --print`) with a prompt
+// synthesised from the family member's system prompt and the duty
+// description. Output is captured into Result.Summary.
+//
+// This is a deliberately thin adapter: we don't parse a structured
+// response, we don't pipe ongoing file edits back in real time. If
+// the model writes files directly (which the claude CLI does when its
+// permission mode is permissive), those edits live in the repo
+// checkout when the subprocess exits — gitops picks them up from
+// there. Runner's note-PR fallback still fires if no files changed.
+type Claude struct {
+	// Bin is the claude binary path. Default: "claude".
+	Bin string
+	// ExtraArgs is appended after the defaults. Handy for things like
+	// "--dangerously-skip-permissions" or "--model claude-opus-4-7".
+	ExtraArgs []string
+	// Timeout caps how long a single Run blocks. Default: 20 minutes.
+	Timeout time.Duration
+}
+
+// NewClaude returns a Claude provider with sensible defaults.
+func NewClaude() *Claude {
+	return &Claude{
+		Bin:     "claude",
+		Timeout: 20 * time.Minute,
+	}
+}
+
+// Name is "claude".
+func (c *Claude) Name() string { return "claude" }
+
+// Run invokes `claude --print` with a combined prompt. stdout becomes
+// Summary; stderr is folded into the error on non-zero exit.
+func (c *Claude) Run(ctx context.Context, req Request) (*Result, error) {
+	if c.Bin == "" {
+		c.Bin = "claude"
+	}
+	if c.Timeout == 0 {
+		c.Timeout = 20 * time.Minute
+	}
+	if _, err := exec.LookPath(c.Bin); err != nil {
+		return &Result{Err: fmt.Errorf("claude: binary %q not found on $PATH: %w", c.Bin, err)},
+			fmt.Errorf("claude binary not available")
+	}
+
+	prompt := composePrompt(req)
+
+	// Subprocess-local ctx: we want to respect the caller's ctx but also
+	// enforce our own Timeout ceiling.
+	cctx, cancel := context.WithTimeout(ctx, c.Timeout)
+	defer cancel()
+
+	args := append([]string{"--print"}, c.ExtraArgs...)
+	cmd := exec.CommandContext(cctx, c.Bin, args...)
+	if req.RepoRoot != "" {
+		cmd.Dir = req.RepoRoot
+	}
+	cmd.Stdin = strings.NewReader(prompt)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	out := stdout.String()
+	if err != nil {
+		if errors.Is(cctx.Err(), context.DeadlineExceeded) {
+			return &Result{Err: fmt.Errorf("claude: timed out after %s", c.Timeout)}, nil
+		}
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return &Result{Err: ctx.Err()}, ctx.Err()
+		}
+		return &Result{
+			Err:     fmt.Errorf("claude exited with error: %w\n%s", err, strings.TrimSpace(stderr.String())),
+			Summary: out,
+		}, nil
+	}
+	return &Result{
+		Summary: strings.TrimSpace(out),
+	}, nil
+}
+
+// composePrompt builds the input we hand to claude --print on stdin.
+// Keeps the member's persona + the duty's description + any duty-
+// specific context visible to the model in one pass.
+func composePrompt(req Request) string {
+	var b strings.Builder
+	if req.MemberPrompt != "" {
+		b.WriteString("# Persona\n\n")
+		b.WriteString(strings.TrimSpace(req.MemberPrompt))
+		b.WriteString("\n\n")
+	}
+	b.WriteString("# Task\n\n")
+	b.WriteString("You are ")
+	b.WriteString(req.Member)
+	b.WriteString(". Tonight's duty: ")
+	b.WriteString(req.Duty)
+	b.WriteString(".\n\n")
+	if req.DutyPrompt != "" {
+		b.WriteString(strings.TrimSpace(req.DutyPrompt))
+		b.WriteString("\n\n")
+	}
+	b.WriteString("# Repository\n\n")
+	b.WriteString("Working directory: ")
+	b.WriteString(req.RepoRoot)
+	b.WriteString("\n\n")
+	b.WriteString("# Output expectations\n\n")
+	b.WriteString("- Keep any edits small and scoped to this duty.\n")
+	b.WriteString("- When you finish, print a short markdown summary to stdout — that text becomes the PR body.\n")
+	b.WriteString("- Never commit or push; night-family handles git for you.\n")
+	b.WriteString("- Never modify files outside the working directory.\n")
+	if len(req.Args) > 0 {
+		b.WriteString("\n# Duty args\n\n")
+		for k, v := range req.Args {
+			fmt.Fprintf(&b, "- %s: %v\n", k, v)
+		}
+	}
+	return b.String()
+}

--- a/internal/provider/claude_test.go
+++ b/internal/provider/claude_test.go
@@ -1,0 +1,94 @@
+package provider
+
+import (
+	"context"
+	"os/exec"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+)
+
+// stubBin writes a tiny shell script to t.TempDir and returns its
+// path. The script echoes whatever stdin handed it prefixed by a
+// header, so composePrompt is observable in the test.
+func stubBin(t *testing.T, script string) string {
+	t.Helper()
+	if _, err := exec.LookPath("sh"); err != nil {
+		t.Skip("sh not available")
+	}
+	dir := t.TempDir()
+	path := filepath.Join(dir, "claude")
+	if err := writeExec(path, script); err != nil {
+		t.Fatalf("write stub: %v", err)
+	}
+	return path
+}
+
+// writeExec writes a shebang wrapper and marks it executable.
+func writeExec(path, script string) error {
+	const hdr = "#!/usr/bin/env sh\n"
+	if err := writeFile(path, hdr+script); err != nil {
+		return err
+	}
+	return exec.Command("chmod", "+x", path).Run()
+}
+
+func TestClaudeHappyPath(t *testing.T) {
+	bin := stubBin(t, `cat <<EOF
+summary line one
+summary line two
+EOF
+`)
+	c := &Claude{Bin: bin, Timeout: 5 * time.Second}
+	res, err := c.Run(context.Background(), Request{
+		Member:       "rick",
+		MemberPrompt: "you are rick",
+		Duty:         "vuln-scan",
+		DutyPrompt:   "find bugs",
+		RepoRoot:     t.TempDir(),
+	})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Err != nil {
+		t.Fatalf("res.Err = %v", res.Err)
+	}
+	if !strings.Contains(res.Summary, "summary line one") {
+		t.Errorf("Summary = %q", res.Summary)
+	}
+}
+
+func TestClaudeFailureExitCode(t *testing.T) {
+	bin := stubBin(t, `echo "boom" >&2; exit 3`)
+	c := &Claude{Bin: bin, Timeout: 5 * time.Second}
+	res, _ := c.Run(context.Background(), Request{Member: "rick", Duty: "x"})
+	if res == nil || res.Err == nil {
+		t.Fatalf("expected res.Err, got res=%v", res)
+	}
+	if !strings.Contains(res.Err.Error(), "boom") {
+		t.Errorf("err = %v", res.Err)
+	}
+}
+
+func TestClaudeMissingBinary(t *testing.T) {
+	c := &Claude{Bin: "definitely-not-a-real-binary-9f8e7d"}
+	res, err := c.Run(context.Background(), Request{Member: "rick", Duty: "x"})
+	if res == nil || res.Err == nil {
+		t.Fatalf("expected res.Err when binary is missing, got res=%v err=%v", res, err)
+	}
+}
+
+func TestComposePromptIncludesEssentials(t *testing.T) {
+	out := composePrompt(Request{
+		Member: "morty", MemberPrompt: "you are morty",
+		Duty: "docs-drift", DutyPrompt: "fix docs",
+		RepoRoot: "/tmp/repo",
+		Args:     map[string]any{"foo": 1},
+	})
+	for _, want := range []string{"morty", "you are morty", "docs-drift", "fix docs", "/tmp/repo", "foo: 1"} {
+		if !strings.Contains(out, want) {
+			t.Errorf("composePrompt missing %q\n--- prompt ---\n%s", want, out)
+		}
+	}
+}

--- a/internal/provider/files.go
+++ b/internal/provider/files.go
@@ -1,0 +1,15 @@
+package provider
+
+import (
+	"os"
+	"path/filepath"
+)
+
+// writeFile is a tiny helper so tests can drop executables into
+// t.TempDir without reaching for os.WriteFile directly.
+func writeFile(path, content string) error {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return err
+	}
+	return os.WriteFile(path, []byte(content), 0o755)
+}


### PR DESCRIPTION
## Summary

Iteration 15: night-family can now dispatch through the real Claude Code CLI. The Mock is still the default (no behavioural change for existing deployments); operators opt into Claude with \`--provider claude\`.

## What's in the box

- **\`internal/provider.Claude\`** — spawns \`claude --print\` with a prompt synthesised from \`MemberPrompt + DutyPrompt + RepoRoot + Args\` on stdin. Captures stdout as \`Summary\`; on non-zero exit it folds stderr into \`Result.Err\`. Honours both the caller's ctx and its own \`Timeout\` (20m default).
- **\`composePrompt\`** — structured markdown sections (\`# Persona\`, \`# Task\`, \`# Repository\`, \`# Output expectations\`, \`# Duty args\`). Output expectations explicitly forbid \`git commit\` / \`git push\` (those are night-family's job via gitops).
- **\`nfd\` flags** —
  - \`--provider {mock,claude}\` (default mock)
  - \`--claude-bin PATH\` (default \`claude\`)
  - \`--claude-args "..."\` (e.g. \`"--dangerously-skip-permissions --model claude-opus-4-7"\`)
  - Unknown provider names fail loudly at boot.
- **Tests** — happy path (shell-script stub echoes \`summary line one\`), non-zero exit (3 → err + stderr in message), missing binary (nice error), composePrompt contains every expected section.

## Design notes

- **Why shell out.** Same reasoning as gitops: the CLI already handles auth, model selection, working-dir cwd, permission modes, etc. Reimplementing against raw API would lose all of that.
- **No structured response parsing (yet).** When Claude makes file edits in permission mode, those edits are on disk when the subprocess exits. The gitops orchestrator (iteration 13) picks up whatever's changed — no further plumbing needed for v1.
- **Note-PR fallback still fires** if the model summarised without editing any file — the morning reviewer still gets *something*.

## Demo recipe

\`\`\`
# Install claude CLI, auth once, then:
nfd \\
  --db ~/.local/share/night-family/nf.db \\
  --repo /path/to/target-repo \\
  --provider claude \\
  --claude-args "--dangerously-skip-permissions" \\
  --auto-trigger
\`\`\`

## Test plan

- [x] \`task check\` passes
- [x] Happy path (stub bin): Summary = "summary line one\\nsummary line two"
- [x] Non-zero exit: err contains stderr message
- [x] Missing binary: returns err at LookPath
- [x] \`--provider foo\` fails loudly at boot
- [ ] CI green

## Follow-ups

- Structured response parsing (e.g. wrap output in a fenced JSON block and extract branch suggestions).
- Token counts — claude CLI may emit them in a trailer; parse + surface.
- Per-member provider / model override (family YAML already has \`provider:\`).
- Codex + Copilot adapters behind the same interface.

cc @coderabbitai @cubic-dev-ai — please review: the prompt composition (especially the "never commit" guidance), the stderr-on-failure handling, and whether --claude-args as a space-split string is painful in practice (vs repeated --claude-arg flags).

🤖 Generated with [Claude Code](https://claude.com/claude-code)