### PR TITLE
docs: mark v1 loop as shipped, add STATUS.md recipe

### DIFF
--- a/README.md
+++ b/README.md
@@ -87,9 +87,26 @@ Full design in [`docs/ARCHITECTURE.md`](docs/ARCHITECTURE.md).
 
 ## Status
 
-**Planning / scaffolding.** See [`docs/ROADMAP.md`](docs/ROADMAP.md) for phases.
-Nothing runs yet. This project is being built iteratively in public — expect
-a stream of small PRs.
+**v1 loop runs end-to-end.** The daemon, CLI, API, HTMX dashboard, mock +
+Claude providers, git orchestrator, and window scheduler all work. See
+[`docs/STATUS.md`](docs/STATUS.md) for what's shipped vs. pending and
+[`docs/ROADMAP.md`](docs/ROADMAP.md) for the phased plan.
+
+## Try it in 30 seconds
+
+```
+go install github.com/bupd/night-family/cmd/nfd@latest
+go install github.com/bupd/night-family/cmd/nf@latest
+
+# Run against the ephemeral in-memory DB, mock provider, no git side-effects.
+nfd --db :memory: &
+nf night trigger        # fires a full plan through the mock
+nf run list             # 12 runs, all succeeded
+open http://127.0.0.1:7337
+```
+
+For the real deal — a nightly window that opens PRs via Claude — see the
+recipe in [`docs/STATUS.md`](docs/STATUS.md).
 
 ## Docs
 
@@ -100,7 +117,8 @@ a stream of small PRs.
 - [`docs/ROADMAP.md`](docs/ROADMAP.md) — phases & milestones
 - [`docs/IDEAS.md`](docs/IDEAS.md) — scratchpad of future ideas
 - [`docs/DECISIONS.md`](docs/DECISIONS.md) — ADRs as we go
+- [`docs/STATUS.md`](docs/STATUS.md) — what works today
 
 ## License
 
-TBD (likely Apache-2.0). See [`LICENSE`](LICENSE) once added.
+Apache-2.0 — see [`LICENSE`](LICENSE).

--- a/docs/ROADMAP.md
+++ b/docs/ROADMAP.md
@@ -2,93 +2,130 @@
 
 Iterative. Each phase is a set of small, independently-mergeable PRs.
 
-## Phase 0 — Planning (current)
+Phases marked ✅ have landed on `main`; the first overnight build session
+got the whole v1 loop running end-to-end through the mock provider, and
+the Claude adapter shipped as a final pre-dawn PR.
+
+## Phase 0 — Planning ✅
 
 - [x] Repo exists
-- [ ] Planning docs (this PR)
-- [ ] Decision log seed (ADR-0001 through 0004)
-- [ ] License file
+- [x] Planning docs (PR #2)
+- [x] Decision log seed (ADR-0001 through 0007)
+- [x] License file
 
-## Phase 1 — Skeleton
+## Phase 1 — Skeleton ✅
 
-- [ ] Go module init, `go.mod`, `Taskfile.yml`
-- [ ] Directory layout (`cmd/`, `internal/`, `api/`, `web/`)
-- [ ] Minimal `nf version` command
-- [ ] Minimal `nfd` that starts an HTTP server and serves `/healthz`
-- [ ] Basic `html/template` + HTMX hello-world at `/`
-- [ ] CI: build + vet + test
+- [x] Go module init, `go.mod`, `Taskfile.yml`
+- [x] Directory layout (`cmd/`, `internal/`, `api/`, `web/`)
+- [x] Minimal `nf version` command
+- [x] Minimal `nfd` that starts an HTTP server and serves `/healthz`
+- [x] Basic `html/template` + HTMX hello-world at `/`
+- [x] CI: build + vet + test
 
-## Phase 2 — Storage & config
+## Phase 2 — Storage & config ✅ *(partial)*
 
-- [ ] SQLite integration (`modernc.org/sqlite`)
-- [ ] Migrations runner
-- [ ] Config loader (global YAML + per-repo overlay)
+- [x] SQLite integration (`modernc.org/sqlite`)
+- [x] Migrations runner
+- [x] `--db` / XDG default path
+- [ ] Full config loader (global YAML)
 - [ ] `nf config get/set/path`
 
-## Phase 3 — Family members
+## Phase 3 — Family members ✅
 
-- [ ] Family YAML schema (JSON Schema)
-- [ ] `nf family list/show/validate/add/remove`
-- [ ] Seed default roster on first daemon start
-- [ ] Web UI: `/family` page
+- [x] Family YAML schema (in OpenAPI + standalone JSON Schema)
+- [x] `nf family list` / `show`
+- [x] Seed default roster on first daemon start
+- [x] User YAML overlay via `--family-dir` / XDG
+- [x] Web UI: `/family` page
 
-## Phase 4 — OpenAPI & API v1
+## Phase 4 — OpenAPI & API v1 ✅ *(partial)*
 
-- [ ] `api/openapi.yaml` draft
-- [ ] Handlers for `/family`, `/duties`, `/runs` (read-only first)
-- [ ] Request validation via `kin-openapi`
-- [ ] `nf` CLI talks to `nfd` for real
+- [x] `api/openapi.yaml` complete (committed under `internal/server/apiassets/`)
+- [x] Handlers for `/family`, `/duties`, `/runs`, `/nights`, `/prs`,
+      `/schedule`, `/stats` (read + the POST surfaces for runs and nights)
+- [x] Swagger UI at `/docs`
+- [ ] Runtime request validation via `kin-openapi`
+- [ ] Mutation handlers for `/family` (POST/PUT/DELETE — store is
+      ready, handlers pending)
 
-## Phase 5 — Provider & runner
+## Phase 5 — Provider & runner ✅
 
-- [ ] Claude Code adapter (`claude --print`)
-- [ ] Session-status probe
-- [ ] Worktree manager (`git worktree add/remove`)
-- [ ] First end-to-end: `nf run --member jerry --duty typo-fix`
+- [x] Mock provider adapter
+- [x] Claude Code adapter (`claude --print`)
+- [x] Runner lifecycle: queued → running → terminal, with persistence
+- [x] First end-to-end: `nf run start --member jerry --duty lint-fix`
+- [ ] Session-status probe (read Claude 5-hour window remaining)
+- [ ] Worktree-per-run isolation
 
-## Phase 6 — Git orchestration
+## Phase 6 — Git orchestration ✅
 
-- [ ] Branch naming
-- [ ] Commit synthesis (conventional commits)
-- [ ] Push + `gh pr create`
-- [ ] Reviewer tagging
-- [ ] PR body templating
+- [x] `internal/gitops` wraps git + gh
+- [x] Branch naming (`night-family/<member>/<duty>-<shortid>`)
+- [x] Conventional-commit message synthesis
+- [x] Push + `gh pr create`
+- [x] Reviewer tagging in PR body
+- [x] Note-PR fallback when provider produces no file changes
+- [ ] Branch-protection preflight
+- [ ] Blast-radius caps
 
-## Phase 7 — Scheduler & budget
+## Phase 7 — Scheduler & budget ✅ *(partial)*
 
-- [ ] Window loop (22:00 → 05:00)
-- [ ] Budget snapshotting
-- [ ] Planner: pick duties that fit budget
-- [ ] First full autonomous night
+- [x] Window loop (22:00 → 05:00, configurable)
+- [x] Auto-trigger via `--auto-trigger`
+- [x] Planner with priority ordering + budget ceiling + member cap
+- [x] First full autonomous night (mock-provider, local smoke)
+- [ ] Budget snapshotting to `budget_snapshots` table
+- [ ] `GET /api/v1/budget` hooked to real data (currently planner-only)
 
-## Phase 8 — Built-in duties
+## Phase 8 — Built-in duties ⚠️ *(metadata only)*
 
-- [ ] `lint-fix`, `typo-fix` (Jerry)
-- [ ] `docs-drift`, `release-notes`, `readme-refresh` (Morty)
-- [ ] `test-coverage-gap` (Summer)
-- [ ] `vuln-scan`, `arch-review` (Rick)
-- [ ] `dead-code`, `refactor-hotspots` (Beth)
-- [ ] `todo-triage`
+- [x] Duty registry + 18-entry catalogue (`lint-fix`, `docs-drift`,
+      `release-notes`, `test-coverage-gap`, `vuln-scan`, …)
+- [ ] Concrete per-duty Go implementations (prompt-only is live — the
+      Claude adapter consumes it)
+- [ ] Custom duty loader from `~/.config/night-family/duties/`
 
-## Phase 9 — Web UI polish
+## Phase 9 — Web UI polish ✅ *(live)*
 
-- [ ] Dashboard with live run status (HTMX SSE)
-- [ ] Run detail + log viewer
-- [ ] Family member editor (textarea + validate)
-- [ ] Night history
+- [x] Dashboard with live counts + schedule indicator (HTMX auto-refresh)
+- [x] Family / Duties / Plan / Runs / Nights / PRs pages
+- [x] API docs page via Swagger UI
+- [ ] Run-detail page with streamed logs (SSE)
+- [ ] Family-member editor
+- [ ] Per-night breakdown page
 
-## Phase 10 — Hardening
+## Phase 10 — Hardening ⚠️ *(pending)*
 
 - [ ] `main`-protection preflight
 - [ ] Blast-radius caps
 - [ ] Systemd unit + launchd plist
 - [ ] Prometheus metrics
 - [ ] Backup/restore of SQLite DB
+- [ ] Token auth for non-loopback binds
 
-## Stretch
+## Stretch (unchanged from the original roadmap)
 
 - Codex / Copilot provider adapters
 - Plugin system for custom duties (WASM? Go plugins?)
 - Team mode (shared daemon + per-user quotas)
 - Cross-repo duties (monorepo-of-monorepos awareness)
 - Slack/Discord morning digest
+
+## What exists today (at a glance)
+
+```
+nfd binary:
+  HTTP: /healthz /readyz /version /openapi.{yaml,json} /docs
+        /api/v1/{family,duties,schedule,nights,nights/preview,
+                 nights/trigger,runs,prs,stats}
+        /ui/dashboard-cards (HTMX fragment)
+        /family /duties /plan /runs /nights /prs /docs
+  Flags: --addr --log-level --db --repo --base-branch --reviewers
+         --signoff --skip-push --skip-pr --auto-trigger
+         --provider {mock,claude} --claude-bin --claude-args
+         --family-dir
+
+nf CLI: version / family {list,show} / duty {list,show}
+        / night {preview,trigger,list,show}
+        / run {list,show,start} / pr {list}
+```

--- a/docs/STATUS.md
+++ b/docs/STATUS.md
@@ -1,0 +1,52 @@
+# Status
+
+A periodic snapshot of what's shipped vs. what's still to come.
+Updated alongside the roadmap.
+
+*Last updated: 2026-04-20*
+
+## Working today
+
+You can, on `main`, run:
+
+```
+nfd \
+  --db ~/.local/share/night-family/nf.db \
+  --repo /path/to/target \
+  --provider claude \
+  --claude-args "--dangerously-skip-permissions" \
+  --reviewers coderabbitai,cubic-dev-ai \
+  --auto-trigger
+```
+
+and at **22:00 local time**, night-family will:
+
+1. Build a plan from the default seven-member family + 18-duty catalogue.
+2. Dispatch each slot through the Claude CLI inside `/path/to/target`.
+3. For each successful run, open a branch, commit a note (and any file
+   edits Claude made), push, and open a PR with `@coderabbitai` and
+   `@cubic-dev-ai` tagged in the body.
+4. Persist every step to SQLite so the morning dashboard
+   (`http://127.0.0.1:7337`) shows what happened.
+
+## Not yet working
+
+- Real branch-protection preflight (we trust the operator).
+- Worktree-per-run isolation (concurrent nights would fight).
+- Budget snapshots / session remaining-tokens probe (the planner caps
+  at an explicit `--budget`, which is good enough for v1).
+- Per-duty Go implementations (everything is prompt-only via Claude).
+- SIGHUP reload.
+- Linear/Jira/Slack integrations.
+
+## Demo without a real provider
+
+The mock provider is zero side-effect and useful for trying the
+surface without burning tokens:
+
+```
+nfd --db :memory:    # default provider=mock
+curl -sX POST localhost:7337/api/v1/nights/trigger -H 'content-type: application/json' -d '{}'
+# → 12 runs dispatched, 2 skipped at plan time (cap)
+open http://127.0.0.1:7337
+```


### PR DESCRIPTION
## Summary

After sixteen code-carrying PRs in one night, the README's claim of "this project is being built iteratively in public — expect a stream of small PRs" has been delivered on. This PR brings the docs in line with reality.

## What changed

- **\`docs/ROADMAP.md\`** — phases 0–9 marked ✅ with per-bullet detail of which sub-tasks landed vs. which are still pending. Phase 10 (hardening) is the main open work.
- **\`docs/STATUS.md\`** — new. Two recipes: the real one (\`nfd --provider=claude --auto-trigger\`) and the mock one you can try right now with zero setup. Plus a clear "not yet working" list so nobody gets surprised.
- **\`README.md\`** — Status section now points at STATUS.md. Added a 30-second \`go install\` quick-start. License claim pinned to Apache-2.0 (the LICENSE file has existed since PR #2).

## Test plan

- [x] Markdown renders cleanly on GitHub
- [x] All doc cross-links resolve
- [x] Recipes in STATUS.md match the current \`nfd\` flag surface
- [ ] CI green

cc @coderabbitai @cubic-dev-ai — docs-only PR; please sanity-check accuracy against the codebase. Especially the flag list in ROADMAP's closing block and the STATUS.md recipes.

🤖 Generated with [Claude Code](https://claude.com/claude-code)