### PR TITLE
feat(family): CRUD handlers + nf family add/replace/remove/validate

### DIFF
--- a/cmd/nf/client.go
+++ b/cmd/nf/client.go
@@ -26,12 +26,24 @@ func daemonURL() string {
 // apiPost sends a JSON POST and decodes the response. Non-2xx is
 // surfaced as an error.
 func apiPost(path string, body []byte, out any) error {
+	return apiJSON(http.MethodPost, path, body, out)
+}
+
+// apiJSON is the general-purpose JSON roundtripper behind apiPost +
+// PUT + DELETE. Passing body=nil sends no body (useful for DELETE).
+func apiJSON(method, path string, body []byte, out any) error {
 	c := &http.Client{Timeout: 3 * time.Minute}
-	req, err := http.NewRequest(http.MethodPost, daemonURL()+path, bytes.NewReader(body))
+	var r io.Reader
+	if body != nil {
+		r = bytes.NewReader(body)
+	}
+	req, err := http.NewRequest(method, daemonURL()+path, r)
 	if err != nil {
 		return err
 	}
-	req.Header.Set("Content-Type", "application/json")
+	if body != nil {
+		req.Header.Set("Content-Type", "application/json")
+	}
 	req.Header.Set("Accept", "application/json")
 	resp, err := c.Do(req)
 	if err != nil {
@@ -43,6 +55,9 @@ func apiPost(path string, body []byte, out any) error {
 		return fmt.Errorf("daemon returned %s: %s", resp.Status, string(b))
 	}
 	if out == nil {
+		return nil
+	}
+	if resp.StatusCode == http.StatusNoContent {
 		return nil
 	}
 	return json.NewDecoder(resp.Body).Decode(out)

--- a/cmd/nf/family.go
+++ b/cmd/nf/family.go
@@ -6,13 +6,80 @@ import (
 	"fmt"
 	"os"
 	"text/tabwriter"
+
+	"gopkg.in/yaml.v3"
 )
 
-const familyUsage = `nf family — inspect the family roster
+// familyWrite is shared by add / replace / validate. It reads a YAML
+// file, converts to JSON, and posts to the daemon. When usePath is
+// true the path is used as-is; otherwise for replace we build it from
+// the member's name.
+func familyWrite(args []string, method, path string, usePath bool) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "nf family: <file.yaml> required")
+		os.Exit(2)
+	}
+	raw, err := os.ReadFile(args[0])
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "nf:", err)
+		os.Exit(1)
+	}
+	var parsed map[string]any
+	if err := yaml.Unmarshal(raw, &parsed); err != nil {
+		fmt.Fprintln(os.Stderr, "nf: invalid YAML:", err)
+		os.Exit(1)
+	}
+	body, _ := json.Marshal(parsed)
+
+	if !usePath {
+		name, _ := parsed["name"].(string)
+		if method == "PUT" {
+			if name == "" {
+				fmt.Fprintln(os.Stderr, "nf: missing name field; PUT target unknown")
+				os.Exit(1)
+			}
+			path = "/api/v1/family/" + name
+		}
+	}
+
+	var resp map[string]any
+	var herr error
+	switch method {
+	case "POST":
+		herr = apiPost(path, body, &resp)
+	case "PUT":
+		herr = apiJSON("PUT", path, body, &resp)
+	}
+	if herr != nil {
+		fmt.Fprintln(os.Stderr, "nf:", herr)
+		os.Exit(1)
+	}
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	_ = enc.Encode(resp)
+}
+
+func familyRemove(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "nf family remove: <name> required")
+		os.Exit(2)
+	}
+	if err := apiJSON("DELETE", "/api/v1/family/"+args[0], nil, nil); err != nil {
+		fmt.Fprintln(os.Stderr, "nf:", err)
+		os.Exit(1)
+	}
+	fmt.Printf("removed: %s\n", args[0])
+}
+
+const familyUsage = `nf family — inspect or mutate the family roster
 
 Usage:
-  nf family list              List all loaded family members
-  nf family show <name>       Show a single member as JSON
+  nf family list                  List all loaded family members
+  nf family show <name>           Show a single member as JSON
+  nf family add <file.yaml>       POST a new member (conflict = 409)
+  nf family replace <file.yaml>   PUT replace an existing member
+  nf family remove <name>         DELETE a member
+  nf family validate <file.yaml>  Check a file without storing
 `
 
 // familyMember mirrors the JSON shape returned by /api/v1/family*. Kept
@@ -39,6 +106,14 @@ func familyCmd(args []string) {
 		familyList(args[1:])
 	case "show":
 		familyShow(args[1:])
+	case "add":
+		familyWrite(args[1:], "POST", "/api/v1/family", true)
+	case "replace":
+		familyWrite(args[1:], "PUT", "", false)
+	case "remove":
+		familyRemove(args[1:])
+	case "validate":
+		familyWrite(args[1:], "POST", "/api/v1/family/validate", false)
 	case "help", "-h", "--help":
 		fmt.Print(familyUsage)
 	default:

--- a/internal/family/family.go
+++ b/internal/family/family.go
@@ -165,6 +165,11 @@ func parseFile(dir fs.FS, name string) (Member, error) {
 	return m, nil
 }
 
+// ApplyDefaults fills in documented defaults for fields the caller
+// omitted. Exported so API handlers can mirror the Store's validation
+// contract before calling Validate.
+func (m *Member) ApplyDefaults() { m.applyDefaults() }
+
 // applyDefaults fills in documented defaults for fields the YAML omitted.
 func (m *Member) applyDefaults() {
 	if m.RiskTolerance == "" {

--- a/internal/server/family.go
+++ b/internal/server/family.go
@@ -8,6 +8,14 @@ import (
 	"github.com/bupd/night-family/internal/family"
 )
 
+func decodeMember(r *http.Request) (family.Member, error) {
+	var m family.Member
+	if err := json.NewDecoder(r.Body).Decode(&m); err != nil {
+		return m, err
+	}
+	return m, nil
+}
+
 // familyRoutes registers the /api/v1/family* endpoints on the given mux.
 // Wired only when cfg.Family is non-nil.
 func (s *Server) familyRoutes(mux *http.ServeMux) {
@@ -16,7 +24,103 @@ func (s *Server) familyRoutes(mux *http.ServeMux) {
 	}
 	mux.HandleFunc("GET /api/v1/family", s.listFamily)
 	mux.HandleFunc("GET /api/v1/family/{name}", s.getFamilyMember)
+	mux.HandleFunc("POST /api/v1/family", s.createFamilyMember)
+	mux.HandleFunc("PUT /api/v1/family/{name}", s.replaceFamilyMember)
+	mux.HandleFunc("DELETE /api/v1/family/{name}", s.deleteFamilyMember)
+	mux.HandleFunc("POST /api/v1/family/validate", s.validateFamilyMember)
 	mux.HandleFunc("GET /family", s.familyPage)
+}
+
+func (s *Server) createFamilyMember(w http.ResponseWriter, r *http.Request) {
+	m, err := decodeMember(r)
+	if err != nil {
+		writeProblem(w, http.StatusBadRequest, "bad_request", "invalid JSON body: "+err.Error(), r.URL.Path)
+		return
+	}
+	stored, err := s.cfg.Family.Add(m)
+	if err != nil {
+		var ve family.ValidationError
+		if errors.As(err, &ve) {
+			writeValidation(w, http.StatusBadRequest, ve, r.URL.Path)
+			return
+		}
+		if errors.Is(err, family.ErrDuplicate) {
+			writeProblem(w, http.StatusConflict, "duplicate", err.Error(), r.URL.Path)
+			return
+		}
+		writeProblem(w, http.StatusInternalServerError, "internal_error", err.Error(), r.URL.Path)
+		return
+	}
+	writeJSON(w, http.StatusCreated, stored)
+}
+
+func (s *Server) replaceFamilyMember(w http.ResponseWriter, r *http.Request) {
+	m, err := decodeMember(r)
+	if err != nil {
+		writeProblem(w, http.StatusBadRequest, "bad_request", "invalid JSON body: "+err.Error(), r.URL.Path)
+		return
+	}
+	name := r.PathValue("name")
+	if m.Name == "" {
+		m.Name = name
+	}
+	if m.Name != name {
+		writeProblem(w, http.StatusBadRequest, "bad_request",
+			"body.name does not match URL name", r.URL.Path)
+		return
+	}
+	stored, err := s.cfg.Family.Put(m)
+	if err != nil {
+		var ve family.ValidationError
+		if errors.As(err, &ve) {
+			writeValidation(w, http.StatusBadRequest, ve, r.URL.Path)
+			return
+		}
+		writeProblem(w, http.StatusInternalServerError, "internal_error", err.Error(), r.URL.Path)
+		return
+	}
+	writeJSON(w, http.StatusOK, stored)
+}
+
+func (s *Server) deleteFamilyMember(w http.ResponseWriter, r *http.Request) {
+	name := r.PathValue("name")
+	err := s.cfg.Family.Remove(name)
+	if errors.Is(err, family.ErrNotFound) {
+		writeProblem(w, http.StatusNotFound, "not_found", "Family member not found", r.URL.Path)
+		return
+	}
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "internal_error", err.Error(), r.URL.Path)
+		return
+	}
+	w.WriteHeader(http.StatusNoContent)
+}
+
+func (s *Server) validateFamilyMember(w http.ResponseWriter, r *http.Request) {
+	m, err := decodeMember(r)
+	if err != nil {
+		writeProblem(w, http.StatusBadRequest, "bad_request", "invalid JSON body: "+err.Error(), r.URL.Path)
+		return
+	}
+	m.ApplyDefaults()
+	issues := family.Validate(m)
+	writeJSON(w, http.StatusOK, map[string]any{
+		"ok":     len(issues) == 0,
+		"errors": issues,
+	})
+}
+
+func writeValidation(w http.ResponseWriter, status int, ve family.ValidationError, instance string) {
+	w.Header().Set("Content-Type", "application/problem+json")
+	w.WriteHeader(status)
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"type":     "https://night-family.dev/errors/validation",
+		"title":    "Invalid family member",
+		"status":   status,
+		"detail":   ve.Error(),
+		"instance": instance,
+		"errors":   ve,
+	})
 }
 
 func (s *Server) listFamily(w http.ResponseWriter, _ *http.Request) {

--- a/internal/server/family_crud_test.go
+++ b/internal/server/family_crud_test.go
@@ -1,0 +1,151 @@
+package server
+
+import (
+	"bytes"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/bupd/night-family/internal/family"
+)
+
+func newTestServerBlankFamily(t *testing.T) (*Server, *family.Store) {
+	t.Helper()
+	fam := family.NewStore()
+	s, err := New(Config{
+		Addr:   "127.0.0.1:0",
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Family: fam,
+	})
+	if err != nil {
+		t.Fatalf("server.New: %v", err)
+	}
+	return s, fam
+}
+
+func postJSON(t *testing.T, s *Server, method, path string, body any) *httptest.ResponseRecorder {
+	t.Helper()
+	var buf bytes.Buffer
+	if body != nil {
+		_ = json.NewEncoder(&buf).Encode(body)
+	}
+	req := httptest.NewRequest(method, path, &buf)
+	req.Header.Set("Content-Type", "application/json")
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	return rr
+}
+
+func TestCreateMember(t *testing.T) {
+	s, fam := newTestServerBlankFamily(t)
+	member := map[string]any{
+		"name":          "custom",
+		"role":          "custom role",
+		"system_prompt": "you are custom",
+	}
+	rr := postJSON(t, s, http.MethodPost, "/api/v1/family", member)
+	if rr.Code != http.StatusCreated {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	if _, err := fam.Get("custom"); err != nil {
+		t.Fatalf("member not stored: %v", err)
+	}
+}
+
+func TestCreateMemberDuplicate(t *testing.T) {
+	s, _ := newTestServerBlankFamily(t)
+	body := map[string]any{"name": "dup", "role": "r", "system_prompt": "p"}
+	_ = postJSON(t, s, http.MethodPost, "/api/v1/family", body)
+	rr := postJSON(t, s, http.MethodPost, "/api/v1/family", body)
+	if rr.Code != http.StatusConflict {
+		t.Fatalf("status = %d, want 409", rr.Code)
+	}
+}
+
+func TestCreateMemberInvalid(t *testing.T) {
+	s, _ := newTestServerBlankFamily(t)
+	body := map[string]any{"name": "BAD-CASE", "role": "r"} // missing system_prompt + bad name
+	rr := postJSON(t, s, http.MethodPost, "/api/v1/family", body)
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	if ct := rr.Header().Get("Content-Type"); ct != "application/problem+json" {
+		t.Errorf("content-type = %q", ct)
+	}
+}
+
+func TestReplaceMember(t *testing.T) {
+	s, fam := newTestServerBlankFamily(t)
+	_ = postJSON(t, s, http.MethodPost, "/api/v1/family",
+		map[string]any{"name": "alice", "role": "old", "system_prompt": "p"})
+	rr := postJSON(t, s, http.MethodPut, "/api/v1/family/alice",
+		map[string]any{"name": "alice", "role": "new", "system_prompt": "p2"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	got, _ := fam.Get("alice")
+	if got.Role != "new" {
+		t.Errorf("role = %q, want new", got.Role)
+	}
+}
+
+func TestReplaceMemberMismatchedName(t *testing.T) {
+	s, _ := newTestServerBlankFamily(t)
+	rr := postJSON(t, s, http.MethodPut, "/api/v1/family/alice",
+		map[string]any{"name": "bob", "role": "r", "system_prompt": "p"})
+	if rr.Code != http.StatusBadRequest {
+		t.Fatalf("status = %d, want 400", rr.Code)
+	}
+}
+
+func TestDeleteMember(t *testing.T) {
+	s, fam := newTestServerBlankFamily(t)
+	_ = postJSON(t, s, http.MethodPost, "/api/v1/family",
+		map[string]any{"name": "temp", "role": "r", "system_prompt": "p"})
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/family/temp", nil)
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusNoContent {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	if _, err := fam.Get("temp"); err == nil {
+		t.Errorf("expected ErrNotFound after delete")
+	}
+}
+
+func TestDeleteMemberMissing(t *testing.T) {
+	s, _ := newTestServerBlankFamily(t)
+	req := httptest.NewRequest(http.MethodDelete, "/api/v1/family/ghost", nil)
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d, want 404", rr.Code)
+	}
+}
+
+func TestValidateMember(t *testing.T) {
+	s, _ := newTestServerBlankFamily(t)
+	rr := postJSON(t, s, http.MethodPost, "/api/v1/family/validate",
+		map[string]any{"name": "ok", "role": "r", "system_prompt": "p"})
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	var body map[string]any
+	_ = json.Unmarshal(rr.Body.Bytes(), &body)
+	if body["ok"] != true {
+		t.Errorf("ok = %v, want true", body["ok"])
+	}
+
+	rr = postJSON(t, s, http.MethodPost, "/api/v1/family/validate",
+		map[string]any{"name": "BAD"}) // missing role + system_prompt
+	if rr.Code != http.StatusOK {
+		t.Fatalf("validate status = %d", rr.Code)
+	}
+	_ = json.Unmarshal(rr.Body.Bytes(), &body)
+	if body["ok"] != false {
+		t.Errorf("ok = %v, want false", body["ok"])
+	}
+}


### PR DESCRIPTION
## Summary

Iteration 19: rounds out \`/api/v1/family\` with POST/PUT/DELETE + validate, and lights up the matching CLI commands. Users can now fully manage the roster from a YAML file without editing the config dir manually.

## API surface landed

| Method | Path | 2xx | Errors |
|--------|------|-----|--------|
| POST   | \`/api/v1/family\`            | 201 + member | 400 validation, 409 duplicate |
| PUT    | \`/api/v1/family/{name}\`     | 200 + member | 400 validation / body-name mismatch |
| DELETE | \`/api/v1/family/{name}\`     | 204          | 404 |
| POST   | \`/api/v1/family/validate\`   | 200 \`{ok, errors[]}\` | — |

Validation errors come through as \`application/problem+json\` with a top-level \`errors\` array carrying each \`{path, message}\` so UIs can render per-field feedback.

## CLI

\`\`\`
nf family add     <file.yaml>   # POST
nf family replace <file.yaml>   # PUT (URL name derived from body.name)
nf family remove  <name>        # DELETE
nf family validate <file.yaml>  # POST /validate — no store mutation
\`\`\`

Under the hood, the CLI shares a new \`apiJSON\` helper that generalises the existing \`apiPost\` across all four verbs.

## Internal

- \`family.Member.ApplyDefaults\` is now exported so the \`/validate\` handler can mirror \`Store.Put\`'s contract (defaults first, then \`Validate\`) — otherwise a valid-looking-member would fail on missing \`risk_tolerance\` etc.

## Test plan

- [x] \`task check\` passes
- [x] Create success → 201, store holds the member
- [x] Create duplicate → 409
- [x] Create invalid name/role/prompt → 400 + problem+json
- [x] PUT replace → 200, fields updated
- [x] PUT with mismatched body name → 400
- [x] DELETE existing → 204; DELETE missing → 404
- [x] /validate returns \`{ok: true}\` for a minimal member and \`{ok: false}\` for a broken one
- [ ] CI green

## Out of scope

- Persisting create/update back to the YAML overlay directory (today this is in-memory only; restarting nfd reverts changes to what disk holds).
- PATCH semantics — we use PUT replace exclusively.

cc @coderabbitai @cubic-dev-ai — please review: (1) the problem+json shape with a top-level \`errors\` array (non-standard extension — acceptable?), (2) the body.name / URL.name consistency check on PUT, (3) the \`--file\` wire-format choice (YAML → unmarshal-remarshal → JSON over the wire).

🤖 Generated with [Claude Code](https://claude.com/claude-code)