### PR TITLE
feat(budget): persist snapshots + serve /api/v1/budget

### DIFF
--- a/internal/runner/night.go
+++ b/internal/runner/night.go
@@ -60,6 +60,19 @@ func (r *Runner) TriggerNight(ctx context.Context, sched *schedule.Schedule, opt
 		return NightResult{}, fmt.Errorf("runner: insert night: %w", err)
 	}
 
+	// Record a budget snapshot at night start so the dashboard /
+	// /api/v1/budget can show "we reserved X of an estimated Y
+	// remaining" without extra probing. The remaining estimate is
+	// best-effort; once a session-status probe lands this becomes a
+	// real observation.
+	_, _ = r.deps.Storage.InsertBudgetSnapshot(ctx, storage.BudgetSnapshot{
+		Provider:                r.deps.Provider.Name(),
+		RemainingTokensEstimate: max(plan.BudgetTokens, plan.ReservedTokens*2),
+		ReservedForTonight:      plan.ReservedTokens,
+		WindowEndsAt:            &plan.WindowEnd,
+		Confidence:              "low",
+	})
+
 	var runs []storage.Run
 	if !opts.DryRun {
 		for _, slot := range plan.Slots {

--- a/internal/server/budget.go
+++ b/internal/server/budget.go
@@ -1,0 +1,38 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/bupd/night-family/internal/storage"
+)
+
+func (s *Server) budgetRoutes(mux *http.ServeMux) {
+	if s.cfg.Storage == nil {
+		return
+	}
+	mux.HandleFunc("GET /api/v1/budget", s.getBudget)
+}
+
+func (s *Server) getBudget(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+	snap, err := s.cfg.Storage.LatestBudgetSnapshot(ctx)
+	if errors.Is(err, storage.ErrNotFound) {
+		// No snapshots yet — return an empty shape rather than 404 so
+		// dashboard code doesn't have to special-case.
+		writeJSON(w, http.StatusOK, storage.BudgetSnapshot{
+			TakenAt:    time.Now().UTC(),
+			Provider:   "unknown",
+			Confidence: "low",
+		})
+		return
+	}
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "db_error", err.Error(), r.URL.Path)
+		return
+	}
+	writeJSON(w, http.StatusOK, snap)
+}

--- a/internal/server/budget_test.go
+++ b/internal/server/budget_test.go
@@ -1,0 +1,67 @@
+package server
+
+import (
+	"context"
+	"encoding/json"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+	"time"
+
+	"github.com/bupd/night-family/internal/storage"
+)
+
+func TestGetBudgetEmpty(t *testing.T) {
+	db, err := storage.Open(context.Background(), ":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	s, _ := New(Config{
+		Addr:    "127.0.0.1:0",
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Storage: db,
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/budget", nil)
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	var snap map[string]any
+	_ = json.Unmarshal(rr.Body.Bytes(), &snap)
+	if snap["provider"] != "unknown" {
+		t.Errorf("provider = %v, want unknown", snap["provider"])
+	}
+}
+
+func TestGetBudgetWithSnapshot(t *testing.T) {
+	db, _ := storage.Open(context.Background(), ":memory:")
+	t.Cleanup(func() { _ = db.Close() })
+	_, err := db.InsertBudgetSnapshot(context.Background(), storage.BudgetSnapshot{
+		Provider:                "claude",
+		RemainingTokensEstimate: 42000,
+		ReservedForTonight:      10000,
+		TakenAt:                 time.Now().UTC(),
+	})
+	if err != nil {
+		t.Fatalf("insert: %v", err)
+	}
+	s, _ := New(Config{
+		Addr: "127.0.0.1:0", Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Storage: db,
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/budget", nil)
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	var snap map[string]any
+	_ = json.Unmarshal(rr.Body.Bytes(), &snap)
+	if snap["provider"] != "claude" {
+		t.Errorf("provider = %v", snap["provider"])
+	}
+	if snap["remaining_tokens_estimate"].(float64) != 42000 {
+		t.Errorf("remaining = %v", snap["remaining_tokens_estimate"])
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -136,6 +136,7 @@ func (s *Server) routes() http.Handler {
 	s.prsRoutes(mux)
 	s.statsRoutes(mux)
 	s.dashboardRoutes(mux)
+	s.budgetRoutes(mux)
 	mux.HandleFunc("GET /", s.index)
 
 	if staticSub, err := fs.Sub(s.web, "static"); err == nil {

--- a/internal/storage/budget.go
+++ b/internal/storage/budget.go
@@ -1,0 +1,79 @@
+package storage
+
+import (
+	"context"
+	"database/sql"
+	"errors"
+	"time"
+)
+
+// BudgetSnapshot mirrors the openapi schema: a point-in-time estimate
+// of how many tokens we have left in the current provider window.
+type BudgetSnapshot struct {
+	ID                      int64      `json:"id"`
+	TakenAt                 time.Time  `json:"taken_at"`
+	Provider                string     `json:"provider"`
+	RemainingTokensEstimate int        `json:"remaining_tokens_estimate"`
+	WindowEndsAt            *time.Time `json:"window_ends_at,omitempty"`
+	ReservedForTonight      int        `json:"reserved_for_tonight"`
+	Confidence              string     `json:"confidence"`
+}
+
+// InsertBudgetSnapshot persists one sample.
+func (db *DB) InsertBudgetSnapshot(ctx context.Context, b BudgetSnapshot) (int64, error) {
+	if b.Provider == "" {
+		return 0, errors.New("storage: InsertBudgetSnapshot: provider required")
+	}
+	if b.TakenAt.IsZero() {
+		b.TakenAt = time.Now().UTC()
+	}
+	if b.Confidence == "" {
+		b.Confidence = "medium"
+	}
+	res, err := db.raw.ExecContext(ctx, `
+		INSERT INTO budget_snapshots(
+			taken_at, provider, remaining_tokens_estimate,
+			window_ends_at, reserved_for_tonight, confidence
+		) VALUES (?, ?, ?, ?, ?, ?)`,
+		b.TakenAt.UTC().Format(time.RFC3339Nano),
+		b.Provider, b.RemainingTokensEstimate,
+		nullableTime(b.WindowEndsAt), b.ReservedForTonight, b.Confidence,
+	)
+	if err != nil {
+		return 0, err
+	}
+	return res.LastInsertId()
+}
+
+// LatestBudgetSnapshot returns the most recent sample or ErrNotFound.
+func (db *DB) LatestBudgetSnapshot(ctx context.Context) (BudgetSnapshot, error) {
+	row := db.raw.QueryRowContext(ctx, `
+		SELECT id, taken_at, provider, remaining_tokens_estimate,
+			   window_ends_at, reserved_for_tonight, confidence
+		FROM budget_snapshots
+		ORDER BY taken_at DESC, id DESC
+		LIMIT 1`)
+	var b BudgetSnapshot
+	var (
+		taken     string
+		windowEnd sql.NullString
+	)
+	err := row.Scan(&b.ID, &taken, &b.Provider,
+		&b.RemainingTokensEstimate, &windowEnd,
+		&b.ReservedForTonight, &b.Confidence)
+	if errors.Is(err, sql.ErrNoRows) {
+		return BudgetSnapshot{}, ErrNotFound
+	}
+	if err != nil {
+		return BudgetSnapshot{}, err
+	}
+	if t, perr := time.Parse(time.RFC3339Nano, taken); perr == nil {
+		b.TakenAt = t
+	}
+	if windowEnd.Valid {
+		if t, perr := time.Parse(time.RFC3339Nano, windowEnd.String); perr == nil {
+			b.WindowEndsAt = &t
+		}
+	}
+	return b, nil
+}


### PR DESCRIPTION
## Summary

Iteration 20: the budget surface goes live. Every night now records a BudgetSnapshot; \`GET /api/v1/budget\` returns the most recent one.

## What's in the box

- **\`storage.BudgetSnapshot\`** — mirrors the openapi schema exactly (\`taken_at\`, \`provider\`, \`remaining_tokens_estimate\`, \`window_ends_at\`, \`reserved_for_tonight\`, \`confidence\`).
- **\`InsertBudgetSnapshot\` / \`LatestBudgetSnapshot\`** — the minimal CRUD slice \`GET /budget\` needs today.
- **\`runner.TriggerNight\`** — records a snapshot immediately after the Night row insert. \`reserved_for_tonight\` comes from the plan's reserved_tokens. \`remaining_tokens_estimate\` is a deliberately pessimistic best-effort (\`max(budget, reserved*2)\`) until a real session probe lands; \`confidence\` is flagged as \`"low"\`.
- **\`GET /api/v1/budget\`** — latest snapshot, or an empty placeholder shape (\`provider: "unknown"\`, \`confidence: "low"\`) on a clean DB so dashboard code doesn't need a 404 special-case.
- **Tests** — empty-DB placeholder, populated-DB fetch, and the runner integration implicitly exercised by the existing night tests.

## Follow-ups

- Real session-status probe that reads claude's local state (or parses \`claude --print /status\`) and stamps a snapshot at nfd startup + on a timer, not only at night trigger. That's what would flip the confidence dial from "low".
- Budget card on the dashboard grid (wires naturally off this endpoint — one more \`hx-get\` fragment).

cc @coderabbitai @cubic-dev-ai — please review: (1) the placeholder-vs-404 choice for empty-DB reads, (2) the \`max(budget, reserved*2)\` heuristic for \`remaining_tokens_estimate\` (is that coherent to an outsider?), (3) whether \`confidence\` should be an enum on the type vs the current string.

🤖 Generated with [Claude Code](https://claude.com/claude-code)