### PR TITLE
feat(nfd): Prometheus-format /metrics endpoint

### DIFF
--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -1,0 +1,70 @@
+package server
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"net/http"
+	"time"
+)
+
+// bootedAt is stamped when the server struct is constructed (via its
+// package-level init) so /metrics can report process uptime without
+// each Server instance tracking it.
+var bootedAt = time.Now()
+
+func (s *Server) metricsRoutes(mux *http.ServeMux) {
+	mux.HandleFunc("GET /metrics", s.metrics)
+}
+
+// metrics emits a minimal hand-rolled Prometheus text-format payload.
+// We avoid pulling in prometheus/client_golang because the metric set
+// is small and rigidly shaped — a few counters derived from
+// storage.Stats + an uptime gauge. If the metric surface grows past
+// ~dozen series we should revisit.
+func (s *Server) metrics(w http.ResponseWriter, r *http.Request) {
+	w.Header().Set("Content-Type", "text/plain; version=0.0.4; charset=utf-8")
+
+	fmt.Fprintf(w, "# HELP nf_up Whether the daemon is serving requests.\n")
+	fmt.Fprintf(w, "# TYPE nf_up gauge\n")
+	fmt.Fprintf(w, "nf_up 1\n")
+
+	fmt.Fprintf(w, "# HELP nf_uptime_seconds Seconds since the daemon booted.\n")
+	fmt.Fprintf(w, "# TYPE nf_uptime_seconds counter\n")
+	fmt.Fprintf(w, "nf_uptime_seconds %f\n", time.Since(bootedAt).Seconds())
+
+	if s.cfg.Storage == nil {
+		return
+	}
+	ctx, cancel := context.WithTimeout(r.Context(), 3*time.Second)
+	defer cancel()
+	stats, err := s.cfg.Storage.Stats(ctx)
+	if err != nil {
+		_, _ = io.WriteString(w, "# stats: error\n")
+		return
+	}
+
+	fmt.Fprintf(w, "# HELP nf_nights_total Number of nights on record.\n")
+	fmt.Fprintf(w, "# TYPE nf_nights_total counter\n")
+	fmt.Fprintf(w, "nf_nights_total %d\n", stats.Nights)
+
+	fmt.Fprintf(w, "# HELP nf_runs_total Number of dispatched runs.\n")
+	fmt.Fprintf(w, "# TYPE nf_runs_total counter\n")
+	fmt.Fprintf(w, "nf_runs_total %d\n", stats.Runs)
+
+	fmt.Fprintf(w, "# HELP nf_runs_by_status Runs bucketed by terminal status.\n")
+	fmt.Fprintf(w, "# TYPE nf_runs_by_status counter\n")
+	for status, n := range stats.RunsByStatus {
+		fmt.Fprintf(w, "nf_runs_by_status{status=%q} %d\n", status, n)
+	}
+
+	fmt.Fprintf(w, "# HELP nf_prs_total Number of PRs opened.\n")
+	fmt.Fprintf(w, "# TYPE nf_prs_total counter\n")
+	fmt.Fprintf(w, "nf_prs_total %d\n", stats.PRs)
+
+	fmt.Fprintf(w, "# HELP nf_prs_by_state PRs bucketed by GitHub state.\n")
+	fmt.Fprintf(w, "# TYPE nf_prs_by_state counter\n")
+	for state, n := range stats.PRsByState {
+		fmt.Fprintf(w, "nf_prs_by_state{state=%q} %d\n", state, n)
+	}
+}

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -1,0 +1,64 @@
+package server
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bupd/night-family/internal/storage"
+)
+
+func TestMetricsAlwaysServed(t *testing.T) {
+	s, _ := New(Config{
+		Addr:   "127.0.0.1:0",
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d", rr.Code)
+	}
+	ct := rr.Header().Get("Content-Type")
+	if !strings.HasPrefix(ct, "text/plain") {
+		t.Errorf("content-type = %q", ct)
+	}
+	for _, want := range []string{"nf_up 1", "nf_uptime_seconds", "# HELP"} {
+		if !strings.Contains(rr.Body.String(), want) {
+			t.Errorf("body missing %q", want)
+		}
+	}
+}
+
+func TestMetricsIncludesStorageCounts(t *testing.T) {
+	db, err := storage.Open(context.Background(), ":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	_ = db.InsertRun(context.Background(), storage.Run{
+		ID: "run_01HMETRICS0000000000000000", Member: "rick", Duty: "vuln-scan",
+		Status: storage.RunSucceeded, StartedAt: time.Now(),
+	})
+	s, _ := New(Config{
+		Addr: "127.0.0.1:0", Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Storage: db,
+	})
+	req := httptest.NewRequest(http.MethodGet, "/metrics", nil)
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	body := rr.Body.String()
+	for _, want := range []string{
+		"nf_runs_total 1",
+		`nf_runs_by_status{status="succeeded"} 1`,
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q\n--- full body ---\n%s", want, body)
+		}
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -137,6 +137,7 @@ func (s *Server) routes() http.Handler {
 	s.statsRoutes(mux)
 	s.dashboardRoutes(mux)
 	s.budgetRoutes(mux)
+	s.metricsRoutes(mux)
 	mux.HandleFunc("GET /", s.index)
 
 	if staticSub, err := fs.Sub(s.web, "static"); err == nil {


### PR DESCRIPTION
## Summary

Iteration 21: night-family is now scrapable. A minimal hand-rolled \`/metrics\` endpoint exposes uptime + storage-derived counters in Prometheus text format.

## What's in the box

- **\`GET /metrics\`** — content-type \`text/plain; version=0.0.4\`.
- **Baseline series** (always present):
  - \`nf_up\` gauge = 1
  - \`nf_uptime_seconds\` counter
- **Storage-derived** (when \`Storage\` is wired):
  - \`nf_nights_total\`
  - \`nf_runs_total\`
  - \`nf_runs_by_status{status=...}\`
  - \`nf_prs_total\`
  - \`nf_prs_by_state{state=...}\`
- **Tests** — baseline without storage; populated series reflect an inserted run.

## Why no \`prometheus/client_golang\`

Seven series, one endpoint, no histograms, no concurrency-heavy collectors — pulling in the full client lib is strictly worse on dependency weight for this size. The openmetrics spec is tiny; we can regenerate the whole payload per request cheaply. When the metric set grows past a dozen series (or we want histograms) we revisit.

## Test plan

- [x] \`task check\` passes
- [x] \`curl /metrics\` served with or without storage
- [x] Inserting a run bumps \`nf_runs_by_status{status="succeeded"}\`
- [ ] CI green

## Out of scope

- Per-member / per-duty run counters (easy follow-up when there's demand).
- HTTP request metrics (method / status / duration histograms).
- Scraper discovery helpers (prometheus operator annotations, etc.).

cc @coderabbitai @cubic-dev-ai — please review: (1) metric naming (\`nf_\` prefix OK?), (2) hand-rolled vs client_golang trade-off, (3) label cardinality boundaries (no per-night labels anywhere — is that consistent with what a scraper would want?).

🤖 Generated with [Claude Code](https://claude.com/claude-code)