### PR TITLE
feat(config): YAML config file support

### DIFF
--- a/cmd/nfd/main.go
+++ b/cmd/nfd/main.go
@@ -17,6 +17,7 @@ import (
 
 	"strings"
 
+	"github.com/bupd/night-family/internal/config"
 	"github.com/bupd/night-family/internal/duty"
 	"github.com/bupd/night-family/internal/family"
 	"github.com/bupd/night-family/internal/gitops"
@@ -29,20 +30,38 @@ import (
 )
 
 func main() {
-	addr := flag.String("addr", "127.0.0.1:7337", "listen address")
-	logLevel := flag.String("log-level", "info", "log level (debug, info, warn, error)")
-	dbPath := flag.String("db", "", "path to SQLite database (default ~/.local/share/night-family/nf.db; use ':memory:' for ephemeral)")
-	repoRoot := flag.String("repo", "", "enable the git orchestrator against this local checkout (default disabled)")
-	baseBranch := flag.String("base-branch", "main", "base branch for opened PRs")
-	reviewersCSV := flag.String("reviewers", "coderabbitai,cubic-dev-ai", "comma-separated reviewers to tag on opened PRs")
-	signOff := flag.Bool("signoff", true, "add a DCO Signed-off-by trailer to commits")
-	skipPush := flag.Bool("skip-push", false, "orchestrator stops after local commit (does not push)")
-	skipPR := flag.Bool("skip-pr", false, "orchestrator stops after push (does not open a PR)")
-	autoTrigger := flag.Bool("auto-trigger", false, "fire a night automatically when the schedule window opens")
-	familyDir := flag.String("family-dir", "", "directory of extra family YAMLs to overlay on the default roster (default: $XDG_CONFIG_HOME/night-family/family if present)")
-	providerName := flag.String("provider", "mock", "provider to dispatch through: 'mock' or 'claude'")
-	claudeBin := flag.String("claude-bin", "claude", "claude CLI binary path (used when --provider=claude)")
-	claudeArgs := flag.String("claude-args", "", "extra space-separated args to pass to the claude binary")
+	// Peek at the command line for an explicit --config BEFORE
+	// declaring the main flag set. That way the config file's values
+	// can seed the defaults — and any flag the operator passes still
+	// wins on conflict (flag.Parse is the last word).
+	explicitCfg := peekConfigFlag(os.Args[1:])
+	configPath := explicitCfg
+	if configPath == "" {
+		configPath = config.DefaultPath()
+	}
+	cfg, cerr := config.Load(configPath)
+	if cerr != nil {
+		fmt.Fprintln(os.Stderr, "nfd: config load:", cerr)
+		os.Exit(2)
+	}
+
+	_ = flag.String("config", configPath, "path to the nfd config file (YAML; optional)")
+
+	// Apply config values, falling back to the built-in defaults.
+	addr := flag.String("addr", nonEmpty(cfg.Addr, "127.0.0.1:7337"), "listen address")
+	logLevel := flag.String("log-level", nonEmpty(cfg.LogLevel, "info"), "log level (debug, info, warn, error)")
+	dbPath := flag.String("db", cfg.DB, "path to SQLite database (default ~/.local/share/night-family/nf.db; use ':memory:' for ephemeral)")
+	repoRoot := flag.String("repo", cfg.Repo, "enable the git orchestrator against this local checkout (default disabled)")
+	baseBranch := flag.String("base-branch", nonEmpty(cfg.BaseBranch, "main"), "base branch for opened PRs")
+	reviewersCSV := flag.String("reviewers", nonEmpty(joinCSV(cfg.Reviewers), "coderabbitai,cubic-dev-ai"), "comma-separated reviewers to tag on opened PRs")
+	signOff := flag.Bool("signoff", cfg.SignOff == nil || *cfg.SignOff, "add a DCO Signed-off-by trailer to commits")
+	skipPush := flag.Bool("skip-push", cfg.SkipPush, "orchestrator stops after local commit (does not push)")
+	skipPR := flag.Bool("skip-pr", cfg.SkipPR, "orchestrator stops after push (does not open a PR)")
+	autoTrigger := flag.Bool("auto-trigger", cfg.AutoTrigger, "fire a night automatically when the schedule window opens")
+	familyDir := flag.String("family-dir", cfg.FamilyDir, "directory of extra family YAMLs to overlay on the default roster (default: $XDG_CONFIG_HOME/night-family/family if present)")
+	providerName := flag.String("provider", nonEmpty(cfg.Provider, "mock"), "provider to dispatch through: 'mock' or 'claude'")
+	claudeBin := flag.String("claude-bin", nonEmpty(cfg.ClaudeBin, "claude"), "claude CLI binary path (used when --provider=claude)")
+	claudeArgs := flag.String("claude-args", strings.Join(cfg.ClaudeArgs, " "), "extra space-separated args to pass to the claude binary")
 	flag.Parse()
 
 	logger := newLogger(*logLevel)
@@ -214,6 +233,42 @@ func openStorage(ctx context.Context, explicit string, logger *slog.Logger) (*st
 	}
 	logger.Info("storage", "dsn", dsn)
 	return storage.Open(ctx, dsn)
+}
+
+// peekConfigFlag scans args for a --config / -config value without
+// defining a flag set. Supports both "--config=path" and "--config
+// path" forms.
+func peekConfigFlag(args []string) string {
+	for i, a := range args {
+		switch {
+		case a == "--config" || a == "-config":
+			if i+1 < len(args) {
+				return args[i+1]
+			}
+		case strings.HasPrefix(a, "--config="):
+			return strings.TrimPrefix(a, "--config=")
+		case strings.HasPrefix(a, "-config="):
+			return strings.TrimPrefix(a, "-config=")
+		}
+	}
+	return ""
+}
+
+// nonEmpty returns the first argument if non-empty, otherwise fallback.
+func nonEmpty(v, fallback string) string {
+	if v != "" {
+		return v
+	}
+	return fallback
+}
+
+// joinCSV joins a slice of reviewer names with commas, returning ""
+// when the slice is empty.
+func joinCSV(xs []string) string {
+	if len(xs) == 0 {
+		return ""
+	}
+	return strings.Join(xs, ",")
 }
 
 // buildProvider resolves the --provider flag into a provider.Provider

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,66 @@
+// Package config loads the optional nfd config YAML from disk.
+//
+// Precedence (highest to lowest): explicit CLI flag → config file →
+// built-in default. That way operators can set a reasonable baseline
+// in ~/.config/night-family/config.yaml and override per-invocation
+// with flags when debugging.
+package config
+
+import (
+	"errors"
+	"io/fs"
+	"os"
+
+	"gopkg.in/yaml.v3"
+)
+
+// Daemon mirrors the subset of nfd's flags that are sensible to put in
+// a YAML file. Absent fields keep their built-in defaults.
+type Daemon struct {
+	Addr        string   `yaml:"addr"`
+	LogLevel    string   `yaml:"log_level"`
+	DB          string   `yaml:"db"`
+	FamilyDir   string   `yaml:"family_dir"`
+	Provider    string   `yaml:"provider"`
+	ClaudeBin   string   `yaml:"claude_bin"`
+	ClaudeArgs  []string `yaml:"claude_args"`
+	Repo        string   `yaml:"repo"`
+	BaseBranch  string   `yaml:"base_branch"`
+	Reviewers   []string `yaml:"reviewers"`
+	SignOff     *bool    `yaml:"signoff"`
+	SkipPush    bool     `yaml:"skip_push"`
+	SkipPR      bool     `yaml:"skip_pr"`
+	AutoTrigger bool     `yaml:"auto_trigger"`
+}
+
+// Load reads path and returns the parsed Daemon. A missing file is
+// not an error — returns (Daemon{}, nil) so callers can treat "no
+// config" and "empty config" identically.
+func Load(path string) (Daemon, error) {
+	raw, err := os.ReadFile(path)
+	if errors.Is(err, fs.ErrNotExist) {
+		return Daemon{}, nil
+	}
+	if err != nil {
+		return Daemon{}, err
+	}
+	var d Daemon
+	if err := yaml.Unmarshal(raw, &d); err != nil {
+		return Daemon{}, err
+	}
+	return d, nil
+}
+
+// DefaultPath returns the path nfd looks at when the operator doesn't
+// pass --config. Honours XDG_CONFIG_HOME, falls back to
+// ~/.config/night-family/config.yaml.
+func DefaultPath() string {
+	if xdg := os.Getenv("XDG_CONFIG_HOME"); xdg != "" {
+		return xdg + "/night-family/config.yaml"
+	}
+	home, err := os.UserHomeDir()
+	if err != nil || home == "" {
+		return ""
+	}
+	return home + "/.config/night-family/config.yaml"
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,71 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+)
+
+func TestLoadMissingIsEmpty(t *testing.T) {
+	d, err := Load(filepath.Join(t.TempDir(), "nope.yaml"))
+	if err != nil {
+		t.Fatalf("Load missing: %v", err)
+	}
+	if d.Addr != "" || d.Provider != "" || len(d.ClaudeArgs) != 0 {
+		t.Errorf("missing file produced non-zero Daemon: %+v", d)
+	}
+}
+
+func TestLoadParses(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "config.yaml")
+	raw := `
+addr: 127.0.0.1:8001
+log_level: debug
+provider: claude
+claude_args:
+  - --dangerously-skip-permissions
+reviewers:
+  - coderabbitai
+  - cubic-dev-ai
+auto_trigger: true
+`
+	if err := os.WriteFile(path, []byte(raw), 0o644); err != nil {
+		t.Fatalf("write: %v", err)
+	}
+	d, err := Load(path)
+	if err != nil {
+		t.Fatalf("Load: %v", err)
+	}
+	if d.Addr != "127.0.0.1:8001" {
+		t.Errorf("addr = %q", d.Addr)
+	}
+	if d.Provider != "claude" {
+		t.Errorf("provider = %q", d.Provider)
+	}
+	if len(d.ClaudeArgs) != 1 || d.ClaudeArgs[0] != "--dangerously-skip-permissions" {
+		t.Errorf("claude_args = %v", d.ClaudeArgs)
+	}
+	if len(d.Reviewers) != 2 {
+		t.Errorf("reviewers = %v", d.Reviewers)
+	}
+	if !d.AutoTrigger {
+		t.Errorf("auto_trigger not set")
+	}
+}
+
+func TestLoadRejectsInvalidYAML(t *testing.T) {
+	dir := t.TempDir()
+	path := filepath.Join(dir, "bad.yaml")
+	_ = os.WriteFile(path, []byte("addr: [\n"), 0o644)
+	if _, err := Load(path); err == nil {
+		t.Fatalf("expected parse error")
+	}
+}
+
+func TestDefaultPathHonoursXDG(t *testing.T) {
+	t.Setenv("XDG_CONFIG_HOME", "/tmp/xdg-fake")
+	if got := DefaultPath(); got != "/tmp/xdg-fake/night-family/config.yaml" {
+		t.Errorf("path = %q", got)
+	}
+}


### PR DESCRIPTION
## Summary

Iteration 25: nfd now reads \`~/.config/night-family/config.yaml\` (or \`\$XDG_CONFIG_HOME/…\`) for default flag values. Passes a \`--config\` flag to point elsewhere. Flags still win on conflict.

## What's in the box

- **\`internal/config\`** — \`Daemon\` struct mirroring the flag surface, \`Load(path)\` that treats missing-file as an empty config (not an error), \`DefaultPath\` honouring XDG.
- **nfd** — peeks at \`os.Args\` for \`--config\` before declaring its flag set, so the file's values seed defaults. Precedence: **CLI flag > config file > built-in**.

## Example

\`\`\`yaml
# ~/.config/night-family/config.yaml
addr: 127.0.0.1:7337
provider: claude
claude_args:
  - --dangerously-skip-permissions
repo: /home/bupd/code/target
reviewers:
  - coderabbitai
  - cubic-dev-ai
auto_trigger: true
\`\`\`

With that file in place, \`nfd\` alone behaves like \`nfd --provider=claude --repo=... --auto-trigger --reviewers=...\`. Adding \`--provider=mock\` on the command line still overrides to mock.

## Test plan

- [x] \`task check\` passes
- [x] \`Load\` returns empty Daemon for missing file, parses valid YAML, errors on malformed
- [x] \`DefaultPath\` honours XDG
- [x] Live smoke: \`nfd -config /tmp/cfg.yaml -db :memory:\` boots with config-seeded addr and accepts the \`-db\` override
- [ ] CI green

## Out of scope

- Reload on SIGHUP.
- Project-local overlay (\`<repo>/.night-family/config.yaml\`) — doable but not wired yet.
- Config validation beyond YAML well-formedness (e.g. rejecting unknown \`provider\` values at load time vs at use time).

cc @coderabbitai @cubic-dev-ai — please review: (1) the pre-parse os.Args peek vs a two-stage FlagSet reset, (2) SignOff as \`*bool\` to distinguish "unset" from "false" — acceptable or gross?, (3) claude_args as \`[]string\` in YAML vs the space-separated string on the flag.

🤖 Generated with [Claude Code](https://claude.com/claude-code)