### PR TITLE
feat(provider): add Codex CLI adapter

### DIFF
--- a/cmd/nfd/main.go
+++ b/cmd/nfd/main.go
@@ -59,9 +59,11 @@ func main() {
 	skipPR := flag.Bool("skip-pr", cfg.SkipPR, "orchestrator stops after push (does not open a PR)")
 	autoTrigger := flag.Bool("auto-trigger", cfg.AutoTrigger, "fire a night automatically when the schedule window opens")
 	familyDir := flag.String("family-dir", cfg.FamilyDir, "directory of extra family YAMLs to overlay on the default roster (default: $XDG_CONFIG_HOME/night-family/family if present)")
-	providerName := flag.String("provider", nonEmpty(cfg.Provider, "mock"), "provider to dispatch through: 'mock' or 'claude'")
+	providerName := flag.String("provider", nonEmpty(cfg.Provider, "mock"), "provider to dispatch through: 'mock', 'claude', or 'codex'")
 	claudeBin := flag.String("claude-bin", nonEmpty(cfg.ClaudeBin, "claude"), "claude CLI binary path (used when --provider=claude)")
 	claudeArgs := flag.String("claude-args", strings.Join(cfg.ClaudeArgs, " "), "extra space-separated args to pass to the claude binary")
+	codexBin := flag.String("codex-bin", "codex", "codex CLI binary path (used when --provider=codex)")
+	codexArgs := flag.String("codex-args", "", "extra space-separated args to pass to the codex binary")
 	flag.Parse()
 
 	logger := newLogger(*logLevel)
@@ -112,7 +114,7 @@ func main() {
 	}
 	defer db.Close()
 
-	prov, err := buildProvider(*providerName, *claudeBin, *claudeArgs)
+	prov, err := buildProvider(*providerName, *claudeBin, *claudeArgs, *codexBin, *codexArgs)
 	if err != nil {
 		fatal(logger, "provider: %v", err)
 	}
@@ -273,21 +275,30 @@ func joinCSV(xs []string) string {
 
 // buildProvider resolves the --provider flag into a provider.Provider
 // instance. Unknown names fail loudly so users catch typos at boot.
-func buildProvider(name, bin, extraArgs string) (provider.Provider, error) {
+func buildProvider(name, claudeBin, claudeArgs, codexBin, codexArgs string) (provider.Provider, error) {
 	switch name {
 	case "", "mock":
 		return provider.NewMock(), nil
 	case "claude":
 		c := provider.NewClaude()
-		if bin != "" {
-			c.Bin = bin
+		if claudeBin != "" {
+			c.Bin = claudeBin
 		}
-		if extraArgs != "" {
-			c.ExtraArgs = strings.Fields(extraArgs)
+		if claudeArgs != "" {
+			c.ExtraArgs = strings.Fields(claudeArgs)
+		}
+		return c, nil
+	case "codex":
+		c := provider.NewCodex()
+		if codexBin != "" {
+			c.Bin = codexBin
+		}
+		if codexArgs != "" {
+			c.ExtraArgs = strings.Fields(codexArgs)
 		}
 		return c, nil
 	default:
-		return nil, fmt.Errorf("unknown provider %q (valid: mock, claude)", name)
+		return nil, fmt.Errorf("unknown provider %q (valid: mock, claude, codex)", name)
 	}
 }
 

--- a/internal/provider/codex.go
+++ b/internal/provider/codex.go
@@ -1,0 +1,85 @@
+package provider
+
+import (
+	"bytes"
+	"context"
+	"errors"
+	"fmt"
+	"os/exec"
+	"strings"
+	"time"
+)
+
+// Codex invokes the `codex` CLI (OpenAI's Codex command-line agent)
+// in a non-interactive way. The shape is intentionally close to
+// Claude — one shell-out per run, prompt on stdin, summary on stdout,
+// stderr folded into the error on non-zero exit.
+//
+// If the codex CLI later grows a different non-interactive flag
+// surface, the adapter is small enough to update in one place.
+type Codex struct {
+	// Bin is the codex binary path. Default: "codex".
+	Bin string
+	// ExtraArgs is appended after the defaults.
+	ExtraArgs []string
+	// Timeout caps how long a single Run blocks. Default: 20 minutes.
+	Timeout time.Duration
+}
+
+// NewCodex returns a Codex provider with sensible defaults.
+func NewCodex() *Codex {
+	return &Codex{
+		Bin:     "codex",
+		Timeout: 20 * time.Minute,
+	}
+}
+
+// Name is "codex".
+func (c *Codex) Name() string { return "codex" }
+
+// Run spawns the codex CLI with the common night-family prompt.
+func (c *Codex) Run(ctx context.Context, req Request) (*Result, error) {
+	if c.Bin == "" {
+		c.Bin = "codex"
+	}
+	if c.Timeout == 0 {
+		c.Timeout = 20 * time.Minute
+	}
+	if _, err := exec.LookPath(c.Bin); err != nil {
+		return &Result{Err: fmt.Errorf("codex: binary %q not found on $PATH: %w", c.Bin, err)},
+			fmt.Errorf("codex binary not available")
+	}
+
+	prompt := composePrompt(req)
+
+	cctx, cancel := context.WithTimeout(ctx, c.Timeout)
+	defer cancel()
+
+	// v1: non-interactive single-shot via stdin. If the codex CLI
+	// grows a specific flag for this we'll switch to it.
+	args := append([]string{}, c.ExtraArgs...)
+	cmd := exec.CommandContext(cctx, c.Bin, args...)
+	if req.RepoRoot != "" {
+		cmd.Dir = req.RepoRoot
+	}
+	cmd.Stdin = strings.NewReader(prompt)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err := cmd.Run()
+	out := stdout.String()
+	if err != nil {
+		if errors.Is(cctx.Err(), context.DeadlineExceeded) {
+			return &Result{Err: fmt.Errorf("codex: timed out after %s", c.Timeout)}, nil
+		}
+		if errors.Is(ctx.Err(), context.Canceled) {
+			return &Result{Err: ctx.Err()}, ctx.Err()
+		}
+		return &Result{
+			Err:     fmt.Errorf("codex exited with error: %w\n%s", err, strings.TrimSpace(stderr.String())),
+			Summary: out,
+		}, nil
+	}
+	return &Result{Summary: strings.TrimSpace(out)}, nil
+}

--- a/internal/provider/codex_test.go
+++ b/internal/provider/codex_test.go
@@ -1,0 +1,40 @@
+package provider
+
+import (
+	"context"
+	"strings"
+	"testing"
+	"time"
+)
+
+func TestCodexHappyPath(t *testing.T) {
+	bin := stubBin(t, `cat <<EOF
+codex-summary-line
+EOF
+`)
+	c := &Codex{Bin: bin, Timeout: 5 * time.Second}
+	res, err := c.Run(context.Background(), Request{Member: "rick", Duty: "vuln-scan", RepoRoot: t.TempDir()})
+	if err != nil {
+		t.Fatalf("Run: %v", err)
+	}
+	if res.Err != nil {
+		t.Fatalf("res.Err = %v", res.Err)
+	}
+	if !strings.Contains(res.Summary, "codex-summary-line") {
+		t.Errorf("Summary = %q", res.Summary)
+	}
+}
+
+func TestCodexMissingBinary(t *testing.T) {
+	c := &Codex{Bin: "definitely-not-real-codex-8f7"}
+	res, _ := c.Run(context.Background(), Request{Member: "rick", Duty: "x"})
+	if res == nil || res.Err == nil {
+		t.Fatalf("expected res.Err when binary is missing")
+	}
+}
+
+func TestCodexName(t *testing.T) {
+	if (&Codex{}).Name() != "codex" {
+		t.Errorf("wrong name")
+	}
+}


### PR DESCRIPTION
## Summary

Iteration 26: second real provider lands. \`--provider=codex\` spawns the \`codex\` CLI with the same prompt shape + process-wrangling as the Claude adapter. Proves the Provider interface is actually pluggable.

## What's in the box

- **\`internal/provider.Codex\`** — mirror of \`Claude\` (composePrompt on stdin, stdout → Summary, stderr folded into err on non-zero exit, ctx + Timeout discipline).
- **nfd flags** — \`--codex-bin\` (default \`codex\`), \`--codex-args\`. Unknown-provider error now lists all three valid values.
- **Tests** — stub-binary happy path + missing-binary path. Shares the \`stubBin\` helper already used by the Claude tests.

## Why a separate Codex type (vs parameterising Claude)

Providers aren't just different binaries — they have different expected prompt formats, different non-interactive flags, different output contracts as their CLIs evolve. Keeping them as separate types means we can iterate on one without touching the other. The overlap today is small enough that the duplication isn't painful.

If that stops being true we can hoist the common plumbing into a helper; for now two ~60-line files is cheaper than one over-abstracted one.

## Test plan

- [x] \`task check\` passes
- [x] \`--provider=codex\` selects the new adapter
- [x] \`--provider=foo\` still fails loudly
- [ ] CI green

## Out of scope

- Real-world testing against the actual codex CLI (maintainer has it auth'd; will validate out-of-band).
- Copilot / Aider / Opencode adapters — same shape, will land when there's demand.

cc @coderabbitai @cubic-dev-ai — review: (1) separate-type vs parameterised-Claude decision, (2) whether \`composePrompt\` needs provider-specific sections now that it's shared, (3) stubBin sharing across test files in the same package — OK pattern?

🤖 Generated with [Claude Code](https://claude.com/claude-code)