### PR TITLE
feat(digest): serve digest over HTTP + nf digest show

### DIFF
--- a/cmd/nf/digest.go
+++ b/cmd/nf/digest.go
@@ -1,0 +1,52 @@
+package main
+
+import (
+	"fmt"
+	"io"
+	"net/http"
+	"os"
+	"time"
+)
+
+const digestUsage = `nf digest — read a night's morning markdown digest
+
+Usage:
+  nf digest show <night-id>     Print the digest for a night
+`
+
+func digestCmd(args []string) {
+	if len(args) == 0 {
+		fmt.Fprint(os.Stderr, digestUsage)
+		os.Exit(2)
+	}
+	switch args[0] {
+	case "show":
+		digestShow(args[1:])
+	case "help", "-h", "--help":
+		fmt.Print(digestUsage)
+	default:
+		fmt.Fprintf(os.Stderr, "nf digest: unknown subcommand %q\n\n", args[0])
+		fmt.Fprint(os.Stderr, digestUsage)
+		os.Exit(2)
+	}
+}
+
+func digestShow(args []string) {
+	if len(args) == 0 {
+		fmt.Fprintln(os.Stderr, "nf digest show: <night-id> required")
+		os.Exit(2)
+	}
+	c := &http.Client{Timeout: 10 * time.Second}
+	resp, err := c.Get(daemonURL() + "/api/v1/nights/" + args[0] + "/digest")
+	if err != nil {
+		fmt.Fprintln(os.Stderr, "nf:", err)
+		os.Exit(1)
+	}
+	defer resp.Body.Close()
+	if resp.StatusCode != http.StatusOK {
+		b, _ := io.ReadAll(io.LimitReader(resp.Body, 1024))
+		fmt.Fprintf(os.Stderr, "nf: daemon returned %s: %s\n", resp.Status, string(b))
+		os.Exit(1)
+	}
+	_, _ = io.Copy(os.Stdout, resp.Body)
+}

--- a/cmd/nf/main.go
+++ b/cmd/nf/main.go
@@ -31,6 +31,7 @@ Commands:
   budget     Show the latest budget snapshot (show)
   stats      Print the daemon's aggregate stats
   doctor     Probe the daemon for basic liveness
+  digest     Read a night's morning digest (show)
   help       Show this help
 
 Environment:
@@ -65,6 +66,8 @@ func main() {
 		statsCmd(os.Args[2:])
 	case "doctor":
 		doctorCmd(os.Args[2:])
+	case "digest":
+		digestCmd(os.Args[2:])
 	case "help", "--help", "-h":
 		fmt.Print(usage)
 	default:

--- a/internal/server/digest.go
+++ b/internal/server/digest.go
@@ -1,0 +1,68 @@
+package server
+
+import (
+	"context"
+	"errors"
+	"net/http"
+	"time"
+
+	"github.com/bupd/night-family/internal/digest"
+	"github.com/bupd/night-family/internal/storage"
+)
+
+func (s *Server) digestRoutes(mux *http.ServeMux) {
+	if s.cfg.Storage == nil {
+		return
+	}
+	mux.HandleFunc("GET /api/v1/nights/{id}/digest", s.getNightDigest)
+}
+
+// getNightDigest renders the digest for a night on demand, pulled from
+// live DB state so clients don't have to rely on the on-disk file the
+// runner writes at FinishNight. Served as text/markdown so piping
+// `curl … > out.md` Just Works.
+func (s *Server) getNightDigest(w http.ResponseWriter, r *http.Request) {
+	ctx, cancel := context.WithTimeout(r.Context(), 5*time.Second)
+	defer cancel()
+
+	id := r.PathValue("id")
+	night, err := s.cfg.Storage.GetNight(ctx, id)
+	if errors.Is(err, storage.ErrNotFound) {
+		writeProblem(w, http.StatusNotFound, "not_found", "Night not found", r.URL.Path)
+		return
+	}
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "db_error", err.Error(), r.URL.Path)
+		return
+	}
+
+	runs, err := s.cfg.Storage.ListRuns(ctx, storage.ListRunsFilter{Limit: 500})
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "db_error", err.Error(), r.URL.Path)
+		return
+	}
+	// Filter to runs whose night_id matches.
+	filtered := runs[:0]
+	for _, rn := range runs {
+		if rn.NightID != nil && *rn.NightID == id {
+			filtered = append(filtered, rn)
+		}
+	}
+
+	prs, _ := s.cfg.Storage.ListPRs(ctx, 500)
+	byRun := map[string]bool{}
+	for _, rn := range filtered {
+		byRun[rn.ID] = true
+	}
+	filteredPRs := prs[:0]
+	for _, p := range prs {
+		if p.RunID != nil && byRun[*p.RunID] {
+			filteredPRs = append(filteredPRs, p)
+		}
+	}
+
+	body := digest.Render(digest.Night{Night: night, Runs: filtered, PRs: filteredPRs})
+
+	w.Header().Set("Content-Type", "text/markdown; charset=utf-8")
+	_, _ = w.Write([]byte(body))
+}

--- a/internal/server/digest_test.go
+++ b/internal/server/digest_test.go
@@ -1,0 +1,75 @@
+package server
+
+import (
+	"context"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/bupd/night-family/internal/storage"
+)
+
+func TestGetNightDigest(t *testing.T) {
+	db, err := storage.Open(context.Background(), ":memory:")
+	if err != nil {
+		t.Fatalf("Open: %v", err)
+	}
+	t.Cleanup(func() { _ = db.Close() })
+	ctx := context.Background()
+	started := time.Now().UTC()
+	nightID := "night_01HDIGEST00000000000000AA"
+	if err := db.InsertNight(ctx, storage.Night{ID: nightID, StartedAt: started}); err != nil {
+		t.Fatalf("InsertNight: %v", err)
+	}
+	id := nightID
+	if err := db.InsertRun(ctx, storage.Run{
+		ID:      "run_01HDIGESTRUN0000000000000A",
+		NightID: &id,
+		Member:  "jerry", Duty: "lint-fix",
+		Status:    storage.RunSucceeded,
+		StartedAt: started,
+	}); err != nil {
+		t.Fatalf("InsertRun: %v", err)
+	}
+	_ = db.FinishNight(ctx, nightID, started.Add(5*time.Minute), "done")
+
+	s, _ := New(Config{
+		Addr:    "127.0.0.1:0",
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Storage: db,
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/nights/"+nightID+"/digest", nil)
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusOK {
+		t.Fatalf("status = %d body = %s", rr.Code, rr.Body.String())
+	}
+	if !strings.HasPrefix(rr.Header().Get("Content-Type"), "text/markdown") {
+		t.Errorf("content-type = %q", rr.Header().Get("Content-Type"))
+	}
+	for _, want := range []string{"# ", "Night " + nightID, "`jerry`", "`lint-fix`", "succeeded"} {
+		if !strings.Contains(rr.Body.String(), want) {
+			t.Errorf("digest missing %q\n--- body ---\n%s", want, rr.Body.String())
+		}
+	}
+}
+
+func TestGetNightDigestNotFound(t *testing.T) {
+	db, _ := storage.Open(context.Background(), ":memory:")
+	t.Cleanup(func() { _ = db.Close() })
+	s, _ := New(Config{
+		Addr:    "127.0.0.1:0",
+		Logger:  slog.New(slog.NewTextHandler(io.Discard, nil)),
+		Storage: db,
+	})
+	req := httptest.NewRequest(http.MethodGet, "/api/v1/nights/night_missing/digest", nil)
+	rr := httptest.NewRecorder()
+	s.routes().ServeHTTP(rr, req)
+	if rr.Code != http.StatusNotFound {
+		t.Fatalf("status = %d", rr.Code)
+	}
+}

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -138,6 +138,7 @@ func (s *Server) routes() http.Handler {
 	s.dashboardRoutes(mux)
 	s.budgetRoutes(mux)
 	s.metricsRoutes(mux)
+	s.digestRoutes(mux)
 	mux.HandleFunc("GET /", s.index)
 
 	if staticSub, err := fs.Sub(s.web, "static"); err == nil {


### PR DESCRIPTION
## Summary

Iteration 28: the morning digest is no longer just a file on disk — it's an HTTP endpoint and a CLI command. Pipe it, email it, read it on your phone, whatever.

## What's in the box

- **\`GET /api/v1/nights/{id}/digest\`** — streams \`text/markdown; charset=utf-8\`. Rendered on demand from live DB state, not the on-disk copy, so it's always current even if disk writes failed. 404 Problem-Details for unknown ids.
- **\`nf digest show <night-id>\`** — curls the endpoint and writes to stdout.
- **Tests** — populated night round-trips through the endpoint with every expected section; unknown id returns 404.

## Why render on-demand vs serve-from-disk

- Disk write was best-effort (iteration 27) and might be missing.
- DB state is always present as long as the Night/Runs/PRs exist.
- \`Content-Type: text/markdown\` lets \`curl … > morning.md\` Just Work, and Slack / email previews degrade gracefully.
- Cost is negligible — digest render is pure-Go string building over a few hundred rows at most.

## Demo

\`\`\`
nfd --db :memory: &
curl -sX POST localhost:7337/api/v1/nights/trigger -H 'content-type: application/json' -d '{}' | jq -r .id
# night_01KPKZBGXDAA4AC9PYBW2N786B

nf digest show night_01KPKZBGXDAA4AC9PYBW2N786B
# → the markdown from iteration 27's example
\`\`\`

## Test plan

- [x] \`task check\` passes
- [x] Endpoint emits \`text/markdown\` with expected headers
- [x] Unknown id → 404 problem+json
- [x] \`nf digest show\` streams cleanly to stdout
- [ ] CI green

## Out of scope

- \`/digests\` HTML index page listing every past night (trivial follow-up — one extra template off the existing \`ListNights\`).
- Slack/Discord webhook on FinishNight — easy now that the rendered text is a first-class thing.

cc @coderabbitai @cubic-dev-ai — please review: (1) render-on-demand vs serve-from-disk choice, (2) markdown content-type (vs text/plain — some legacy proxies strip unknown types), (3) whether the CLI should default to piping through a pager.

🤖 Generated with [Claude Code](https://claude.com/claude-code)