### PR TITLE
feat(nfd): SIGHUP reloads family-dir without restart

### DIFF
--- a/cmd/nfd/main.go
+++ b/cmd/nfd/main.go
@@ -200,22 +200,54 @@ func main() {
 	go func() { errCh <- srv.ListenAndServe() }()
 
 	sig := make(chan os.Signal, 1)
-	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM)
+	signal.Notify(sig, syscall.SIGINT, syscall.SIGTERM, syscall.SIGHUP)
 
-	select {
-	case err := <-errCh:
-		if err != nil {
-			fatal(logger, "listen: %v", err)
-		}
-	case s := <-sig:
-		logger.Info("shutdown signal", "signal", s.String())
-		ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
-		defer cancel()
-		if err := srv.Shutdown(ctx); err != nil {
-			logger.Error("shutdown", "err", err)
-			os.Exit(1)
+	for {
+		select {
+		case err := <-errCh:
+			if err != nil {
+				fatal(logger, "listen: %v", err)
+			}
+			return
+		case s := <-sig:
+			if s == syscall.SIGHUP {
+				reloadFamily(logger, fam, dir)
+				continue
+			}
+			logger.Info("shutdown signal", "signal", s.String())
+			ctx, cancel := context.WithTimeout(context.Background(), 10*time.Second)
+			defer cancel()
+			if err := srv.Shutdown(ctx); err != nil {
+				logger.Error("shutdown", "err", err)
+				os.Exit(1)
+			}
+			return
 		}
 	}
+}
+
+// reloadFamily re-reads the on-disk family YAMLs and Put()s each into
+// the live store. Invoked by SIGHUP. Name-collision = user file wins
+// (same rule as startup). Deletions on disk don't remove from the
+// store yet — operators needing that should use 'nf family remove'.
+func reloadFamily(logger *slog.Logger, fam *family.Store, dir string) {
+	if dir == "" {
+		logger.Warn("SIGHUP: no family-dir configured, nothing to reload")
+		return
+	}
+	extras, errs := family.LoadDiskDir(dir)
+	for _, e := range errs {
+		logger.Warn("SIGHUP: family-dir load issue", "dir", dir, "err", e)
+	}
+	n := 0
+	for _, m := range extras {
+		if _, err := fam.Put(m); err != nil {
+			logger.Warn("SIGHUP: member rejected", "name", m.Name, "err", err)
+			continue
+		}
+		n++
+	}
+	logger.Info("SIGHUP: family reloaded", "dir", dir, "applied", n, "total", fam.Len())
 }
 
 func newLogger(level string) *slog.Logger {


### PR DESCRIPTION
## Summary

Iteration 30: drop a YAML into the family-dir, send \`kill -HUP \$(pidof nfd)\`, and the new persona is live everywhere — roster, planner, UI — without bouncing the daemon.

## What's in the box

- **\`reloadFamily\`** helper in \`cmd/nfd/main.go\` — re-walks the configured family-dir, pipes each parsed \`Member\` through \`Store.Put\`. Per-file parse errors are logged; per-member validation errors log and skip. Total count logged at the end.
- **\`main\`** signal loop restructured from a \`select\` into a \`for { select }\` so the HUP case can continue serving instead of shutting down. SIGINT/SIGTERM still cleanly drain via \`srv.Shutdown\`.
- **Semantics**
  - Name collision → user file wins (same as startup).
  - Deletions on disk do **not** yet remove from the store; use \`nf family remove\` or POST/DELETE /api/v1/family/{name}. That gap is called out in the commit + the help text.
- **Missing family-dir** → HUP logs a warning and no-ops. SIGINT/SIGTERM still shut down regardless.

## Live smoke (included in the commit body log)

\`\`\`
$ curl -s localhost:7337/api/v1/family | jq 'length'
7

# drop mr-meeseeks.yaml into /tmp/nf-family-hup, then:
$ kill -HUP $(pidof nfd)
# nfd: "SIGHUP: family reloaded dir=/tmp/nf-family-hup applied=1 total=8"

$ curl -s localhost:7337/api/v1/family | jq 'map(.name)'
["beth","birdperson","jerry","morty","mr-meeseeks","rick","squanchy","summer"]
\`\`\`

## Test plan

- [x] \`task check\` passes
- [x] Live smoke: initial 7 → HUP → 8 members (shown above)
- [x] SIGINT still shuts down cleanly
- [ ] CI green

## Out of scope

- Deletion semantics (\"remove a member by deleting its YAML\"). That needs a tombstone concept so we don't drop API-created members that have no file backing. Follow-up PR.
- Reloading schedule / reviewers / claude-args from the config file on HUP. Same trick would work, but those are cheap to change via a quick restart today and would require more plumbing to hot-swap.

cc @coderabbitai @cubic-dev-ai — review: (1) "user file wins" on HUP identical to startup — correct?, (2) the "no delete on disk removal" gap + its call-out, (3) whether the helper belongs in \`cmd/nfd\` (current) or on \`*family.Store\`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)