### PR TITLE
Add test flakiness analyzer and fix e2e flakiness risks

### DIFF
--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -88,6 +88,10 @@ tasks:
       - task: test
       - task: build
 
+  flaky:
+    desc: Run flakiness analyzer (default 5 runs)
+    cmd: scripts/test-flakiness.sh {{.CLI_ARGS | default "5"}}
+
   clean:
     desc: Remove build artefacts
     cmd: rm -rf {{.BIN_DIR}} coverage.txt

--- a/scripts/test-flakiness.sh
+++ b/scripts/test-flakiness.sh
@@ -1,0 +1,151 @@
+#!/usr/bin/env bash
+# test-flakiness.sh — Run tests N times and report flaky tests.
+#
+# Usage: scripts/test-flakiness.sh [COUNT]
+#   COUNT  Number of runs (default: 5)
+#
+# Output: JSON report of tests with inconsistent results.
+
+set -euo pipefail
+
+COUNT="${1:-5}"
+PROJECT_ROOT="$(cd "$(dirname "$0")/.." && pwd)"
+
+echo "=== Flakiness analyzer: running tests ${COUNT} times ===" >&2
+
+tmpdir=$(mktemp -d)
+trap 'rm -rf "$tmpdir"' EXIT
+
+# Run tests COUNT times, collecting JSON output.
+for i in $(seq 1 "$COUNT"); do
+    echo "  run ${i}/${COUNT}..." >&2
+    go test -race -json -count=1 ./... 2>/dev/null > "${tmpdir}/run_${i}.json" || true
+done
+
+# Analyze results with an inline Go program.
+cat > "${tmpdir}/analyze.go" << 'GOEOF'
+package main
+
+import (
+	"encoding/json"
+	"fmt"
+	"io"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+)
+
+type TestEvent struct {
+	Action  string  `json:"Action"`
+	Package string  `json:"Package"`
+	Test    string  `json:"Test"`
+	Elapsed float64 `json:"Elapsed"`
+}
+
+type TestResult struct {
+	Pass int
+	Fail int
+	Skip int
+	Durations []float64
+}
+
+func main() {
+	dir := os.Args[1]
+	count := os.Args[2]
+
+	results := map[string]*TestResult{} // key: "pkg::test"
+
+	entries, _ := filepath.Glob(filepath.Join(dir, "run_*.json"))
+	for _, path := range entries {
+		f, err := os.Open(path)
+		if err != nil {
+			continue
+		}
+		dec := json.NewDecoder(f)
+		for {
+			var ev TestEvent
+			if err := dec.Decode(&ev); err == io.EOF {
+				break
+			} else if err != nil {
+				continue
+			}
+			if ev.Test == "" {
+				continue
+			}
+			if ev.Action != "pass" && ev.Action != "fail" && ev.Action != "skip" {
+				continue
+			}
+			key := ev.Package + "::" + ev.Test
+			if results[key] == nil {
+				results[key] = &TestResult{}
+			}
+			r := results[key]
+			switch ev.Action {
+			case "pass":
+				r.Pass++
+				r.Durations = append(r.Durations, ev.Elapsed)
+			case "fail":
+				r.Fail++
+				r.Durations = append(r.Durations, ev.Elapsed)
+			case "skip":
+				r.Skip++
+			}
+		}
+		f.Close()
+	}
+
+	// Find flaky tests (both pass and fail).
+	type FlakyTest struct {
+		Name     string    `json:"name"`
+		Pass     int       `json:"pass"`
+		Fail     int       `json:"fail"`
+		Skip     int       `json:"skip,omitempty"`
+		Rate     string    `json:"pass_rate"`
+		Durations []float64 `json:"durations_sec"`
+	}
+	var flaky []FlakyTest
+	for key, r := range results {
+		if r.Pass > 0 && r.Fail > 0 {
+			rate := fmt.Sprintf("%.0f%%", float64(r.Pass)/float64(r.Pass+r.Fail)*100)
+			flaky = append(flaky, FlakyTest{
+				Name:     key,
+				Pass:     r.Pass,
+				Fail:     r.Fail,
+				Skip:     r.Skip,
+				Rate:     rate,
+				Durations: r.Durations,
+			})
+		}
+	}
+	sort.Slice(flaky, func(i, j int) bool {
+		return flaky[i].Name < flaky[j].Name
+	})
+
+	totalTests := len(results)
+	report := map[string]any{
+		"runs":        count,
+		"total_tests": totalTests,
+		"flaky_count": len(flaky),
+		"flaky_tests": flaky,
+	}
+
+	enc := json.NewEncoder(os.Stdout)
+	enc.SetIndent("", "  ")
+	enc.Encode(report)
+
+	if len(flaky) > 0 {
+		fmt.Fprintf(os.Stderr, "\n⚠ Found %d flaky test(s) out of %d\n", len(flaky), totalTests)
+		for _, f := range flaky {
+			parts := strings.SplitN(f.Name, "::", 2)
+			fmt.Fprintf(os.Stderr, "  %s (pass=%d fail=%d rate=%s)\n", parts[1], f.Pass, f.Fail, f.Rate)
+		}
+		os.Exit(1)
+	} else {
+		fmt.Fprintf(os.Stderr, "\n✓ No flaky tests found (%d tests, %s runs)\n", totalTests, count)
+	}
+}
+GOEOF
+
+cd "$PROJECT_ROOT"
+go run "${tmpdir}/analyze.go" "$tmpdir" "$COUNT"

--- a/tests/e2e_test.go
+++ b/tests/e2e_test.go
@@ -14,6 +14,7 @@ package e2e
 import (
 	"encoding/json"
 	"fmt"
+	"net"
 	"net/http"
 	"os"
 	"os/exec"
@@ -67,10 +68,23 @@ func projectRoot() string {
 	}
 }
 
-// startNfd launches the built binary with an in-memory DB on a
-// caller-supplied port. Returns (baseURL, stop).
-func startNfd(t *testing.T, port string) (string, func()) {
+// freePort asks the OS for an unused port by binding to :0.
+func freePort(t *testing.T) string {
 	t.Helper()
+	l, err := net.Listen("tcp", "127.0.0.1:0")
+	if err != nil {
+		t.Fatalf("freePort: %v", err)
+	}
+	port := l.Addr().(*net.TCPAddr).Port
+	l.Close()
+	return fmt.Sprintf("%d", port)
+}
+
+// startNfd launches the built binary with an in-memory DB on a
+// dynamically allocated port. Returns (baseURL, stop).
+func startNfd(t *testing.T) (string, func()) {
+	t.Helper()
+	port := freePort(t)
 	addr := "127.0.0.1:" + port
 	cmd := exec.Command(nfdBin, "-db", ":memory:", "-addr", addr, "-log-level", "error")
 	cmd.Stdout = os.Stderr
@@ -86,10 +100,12 @@ func startNfd(t *testing.T, port string) (string, func()) {
 	}
 }
 
-// waitForReady polls /healthz until 200 or timeout.
+// waitForReady polls /healthz with exponential backoff until 200 or timeout.
 func waitForReady(t *testing.T, base string) {
 	t.Helper()
-	deadline := time.Now().Add(5 * time.Second)
+	deadline := time.Now().Add(10 * time.Second)
+	backoff := 25 * time.Millisecond
+	const maxBackoff = 500 * time.Millisecond
 	for time.Now().Before(deadline) {
 		resp, err := http.Get(base + "/healthz")
 		if err == nil {
@@ -98,13 +114,17 @@ func waitForReady(t *testing.T, base string) {
 				return
 			}
 		}
-		time.Sleep(50 * time.Millisecond)
+		time.Sleep(backoff)
+		backoff *= 2
+		if backoff > maxBackoff {
+			backoff = maxBackoff
+		}
 	}
 	t.Fatalf("daemon never became ready at %s", base)
 }
 
 func TestE2E_FullNightThroughMock(t *testing.T) {
-	base, stop := startNfd(t, "17350")
+	base, stop := startNfd(t)
 	t.Cleanup(stop)
 
 	resp, err := http.Post(base+"/api/v1/nights/trigger",
@@ -159,7 +179,7 @@ func TestE2E_FullNightThroughMock(t *testing.T) {
 }
 
 func TestE2E_HealthAndVersion(t *testing.T) {
-	base, stop := startNfd(t, "17351")
+	base, stop := startNfd(t)
 	t.Cleanup(stop)
 
 	for _, path := range []string{"/healthz", "/readyz", "/version", "/openapi.yaml", "/api/v1/family"} {


### PR DESCRIPTION
## Summary
- Add `scripts/test-flakiness.sh` — runs test suite N times with JSON output, detects tests with inconsistent pass/fail results, and reports statistics
- Add `task flaky` target to Taskfile.yml for easy invocation (e.g. `task flaky -- 10`)
- Fix hardcoded ports (17350/17351) in e2e tests with dynamic port allocation via `net.Listen` on port 0
- Replace fixed 50ms polling in `waitForReady()` with exponential backoff (25ms→500ms) to reduce timing sensitivity on slow CI

## Test plan
- [x] All 114 tests pass (`go test -race ./...`)
- [x] Flakiness analyzer validates 0 flaky tests across 10 runs
- [ ] Verify `task flaky` works: `task flaky -- 5`
- [ ] Confirm e2e tests run in parallel without port conflicts

Nightshift-Task: test-flakiness
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: test-flakiness:/var/home/bupd
task-type: test-flakiness
task-title: Test Flakiness Analyzer
provider: claude
score: 3.0
cost-tier: Medium (50-150k)
iterations: 1
duration: 10m5s
run-started: 2026-04-20T00:00:42Z
nightshift:metadata -->
