### PR TITLE
fix: remove unused plainProvider type (staticcheck U1000)

### DIFF
--- a/internal/server/provider_test.go
+++ b/internal/server/provider_test.go
@@ -37,13 +37,6 @@ func TestProviderStatusWithProber(t *testing.T) {
 	}
 }
 
-// plainProvider is a tiny Provider without SessionStatus — used to
-// exercise the status_supported=false branch.
-type plainProvider struct{}
-
-func (plainProvider) Name() string                  { return "plain" }
-func (plainProvider) Run(_ any, _ any) (any, error) { return nil, nil }
-
 func TestProviderStatusWithoutProber(t *testing.T) {
 	// We can't pass a provider that doesn't satisfy the interface at
 	// compile time, so use the Mock but manually route through a


### PR DESCRIPTION
## Summary
- Remove unused `plainProvider` struct and its methods from `internal/server/provider_test.go` to fix staticcheck U1000 diagnostic

## Test plan
- [x] `staticcheck ./...` passes
- [x] `go vet ./...` passes
- [x] `go test ./...` passes

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: lint-fix:/var/home/bupd
task-type: lint-fix
task-title: Linter Fixes
provider: claude
score: 3.0
cost-tier: Low (10-50k)
iterations: 1
duration: 8m57s
run-started: 2026-04-21T00:00:04Z
nightshift:metadata -->
