### PR TITLE
fix: td-review session — 6 bug fixes + 11 deferred tasks

### DIFF
--- a/.td/001-ignored-json-encoding-errors.md
+++ b/.td/001-ignored-json-encoding-errors.md
@@ -1,0 +1,35 @@
+# TD: Systematic ignored JSON encoding errors across CLI
+
+**Priority:** Medium
+**Category:** Bug / Error Handling
+**Scope:** `cmd/nf/*.go`
+
+## Problem
+
+Across 20+ locations in the CLI files, `json.NewEncoder(os.Stdout).Encode(...)` return
+values are discarded with `_ = enc.Encode(...)`. If stdout is a broken pipe or closed fd
+(common when piped to `head`, `grep`, etc.), the write error is silently lost and the
+process exits 0 — misleading in scripts and CI pipelines.
+
+## Affected Files
+
+- `cmd/nf/night.go` (lines 42, 83, 166)
+- `cmd/nf/pr.go` (line 48)
+- `cmd/nf/duty.go` (lines 59, 82)
+- `cmd/nf/family.go` (lines 59, 140, 167)
+- `cmd/nf/run.go` (lines 92, 133, 148)
+
+## Suggested Fix
+
+Create a shared helper like:
+```go
+func writeJSON(v any) {
+    enc := json.NewEncoder(os.Stdout)
+    enc.SetIndent("", "  ")
+    if err := enc.Encode(v); err != nil {
+        fmt.Fprintln(os.Stderr, "nf:", err)
+        os.Exit(1)
+    }
+}
+```
+Then replace all `_ = enc.Encode(...)` call sites with `writeJSON(v)`.

--- a/.td/002-silent-db-errors-runner.md
+++ b/.td/002-silent-db-errors-runner.md
@@ -1,0 +1,26 @@
+# TD: Silent DB errors in runner package non-fatal operations
+
+**Priority:** Medium
+**Category:** Bug / Observability
+**Scope:** `internal/runner/night.go`, `internal/runner/runner.go`
+
+## Problem
+
+Several storage operations in the runner package silently discard errors with `_ =`:
+
+1. `runner/night.go:104` — `_ = r.deps.Storage.FinishNight(...)`: If this fails, the night
+   record is left in a permanently "running" state in the DB. The dashboard and API will
+   show stale in-progress nights.
+
+2. `runner/night.go:71-77` — `_, _ = r.deps.Storage.InsertBudgetSnapshot(...)`: Budget
+   tracking silently breaks if this fails, leading to inaccurate budget displays.
+
+3. `runner/runner.go` — Similar patterns where non-fatal DB ops discard errors without
+   logging.
+
+## Suggested Fix
+
+Replace `_ =` with logging at `Warn` level (consistent with the existing pattern for
+non-fatal errors in the same file, e.g., line 115). Do not return errors from these —
+they are intentionally non-fatal — but ensure they're observable in logs so operators
+can diagnose issues.

--- a/.td/003-stub-session-status-providers.md
+++ b/.td/003-stub-session-status-providers.md
@@ -1,0 +1,24 @@
+# TD: Stub SessionStatus in provider/status.go for Claude and Codex
+
+**Priority:** Low
+**Category:** Feature Gap
+**Scope:** `internal/provider/claude.go`, `internal/provider/codex.go`, `internal/provider/status.go`
+
+## Problem
+
+The `SessionStatus` function in `provider/status.go` is a stub or returns hardcoded
+placeholder values for the Claude and Codex providers. This means:
+
+- The budget dashboard shows estimated/fake remaining token counts.
+- The planner cannot make informed decisions about budget allocation.
+- The `BudgetSnapshot.Confidence` field is always "low" because there's no real probe.
+
+## Suggested Fix
+
+Implement actual session status probing for each provider:
+- **Claude:** Use the Anthropic API's usage/billing endpoint (or infer from response
+  headers) to report real remaining tokens.
+- **Codex:** Use the OpenAI usage API to report remaining quota.
+
+If real probing is not feasible short-term, at minimum log a warning when the stub is
+called so operators know the data is synthetic.

--- a/.td/004-missing-token-counting.md
+++ b/.td/004-missing-token-counting.md
@@ -1,0 +1,24 @@
+# TD: Missing token counting in provider implementations
+
+**Priority:** Medium
+**Category:** Feature Gap / Budget Accuracy
+**Scope:** `internal/provider/claude.go`, `internal/provider/codex.go`
+
+## Problem
+
+Neither the Claude nor Codex provider implementation tracks actual token usage from API
+responses. The `provider.Result` struct has fields for token counts, but they are left at
+zero after a Run completes. This means:
+
+- Budget enforcement is based entirely on planner estimates, not actual consumption.
+- The runs table and dashboard show 0 tokens for every completed run.
+- Budget snapshots accumulate estimation drift over multiple nights.
+
+## Suggested Fix
+
+After each provider API call, parse the response's usage metadata:
+- **Claude:** Extract `input_tokens` and `output_tokens` from the API response.
+- **Codex:** Extract `usage.prompt_tokens` and `usage.completion_tokens`.
+
+Populate `provider.Result.InputTokens` and `provider.Result.OutputTokens` so the runner
+can record accurate usage and the planner can adjust future estimates.

--- a/.td/005-fragile-sql-construction.md
+++ b/.td/005-fragile-sql-construction.md
@@ -1,0 +1,36 @@
+# TD: Fragile SQL query construction in storage/runs.go
+
+**Priority:** High
+**Category:** Bug / Security
+**Scope:** `internal/storage/runs.go`
+
+## Problem
+
+`ListRuns` in `storage/runs.go` (around lines 82-108) builds SQL queries using string
+concatenation with `fmt.Sprintf` or manual `WHERE` clause assembly. While the current
+callers pass controlled values (from URL query params that are typed), this pattern is:
+
+1. **Fragile** — adding a new filter requires careful string manipulation and it's easy
+   to introduce syntax errors (e.g., mismatched `AND`/`WHERE`).
+2. **Injection-adjacent** — if any caller passes unsanitized input, the concatenated SQL
+   becomes a vector. Currently safe because `RunStatus` is a typed string, but this is
+   a latent risk.
+
+## Suggested Fix
+
+Refactor to use a query builder pattern:
+```go
+var clauses []string
+var args []any
+if f.Member != "" {
+    clauses = append(clauses, "member = ?")
+    args = append(args, f.Member)
+}
+// ...
+where := ""
+if len(clauses) > 0 {
+    where = " WHERE " + strings.Join(clauses, " AND ")
+}
+query := "SELECT ... FROM runs" + where + " ORDER BY started_at DESC"
+```
+This is still plain SQL (no ORM), but eliminates the fragile string splicing.

--- a/.td/006-missing-config-validation.md
+++ b/.td/006-missing-config-validation.md
@@ -1,0 +1,23 @@
+# TD: Missing config validation in config/config.go
+
+**Priority:** Medium
+**Category:** Bug / UX
+**Scope:** `internal/config/config.go`
+
+## Problem
+
+`config.Load()` reads the YAML/env config but performs minimal validation. Invalid or
+incomplete configurations are discovered late — often at runtime when a provider call
+fails or a nil pointer is hit. Examples:
+
+- No validation that `provider` is a recognized value ("claude", "codex", "mock").
+- No validation that `schedule.window_start` / `window_end` are valid time strings.
+- No validation that `family_dir` exists or is readable.
+- No validation that `db_path` parent directory is writable.
+- API keys are not checked for non-empty when a real provider is selected.
+
+## Suggested Fix
+
+Add a `Config.Validate() error` method that checks all invariants at load time and
+returns a clear, actionable error message. Call it from `Load()` before returning.
+This gives operators fast feedback on misconfiguration instead of cryptic runtime panics.

--- a/.td/007-test-coverage-runner-night.md
+++ b/.td/007-test-coverage-runner-night.md
@@ -1,0 +1,30 @@
+# TD: CRITICAL — Add test coverage for internal/runner/night.go
+
+**Priority:** Critical
+**Category:** Test Coverage
+**Scope:** `internal/runner/night.go`
+
+## Problem
+
+`runner/night.go` contains the core `TriggerNight` orchestration logic — the most
+important code path in the entire project — but has no dedicated unit tests. The only
+coverage comes indirectly from `scheduler/loop_test.go` which exercises a narrow path.
+
+Untested paths include:
+- `TriggerNight` with various `NightOptions` combinations (OnlyMembers, OnlyDuties, Budget, DryRun)
+- Context cancellation mid-dispatch (the `goto finish` path)
+- `renderDigest` with DB errors, empty runs, nil PRs
+- `writeDigestBody` directory creation and file writing
+- `filterSlots` edge cases (empty allow-lists, partial matches)
+- Notification path (Notifier.Notify success and failure)
+
+## Suggested Approach
+
+Create `internal/runner/night_test.go` with table-driven tests using the mock provider
+and an in-memory SQLite DB (same pattern as `scheduler/loop_test.go`). Key scenarios:
+1. Full night with multiple slots → verify all runs recorded
+2. DryRun=true → verify zero dispatches
+3. OnlyMembers/OnlyDuties filtering
+4. Context cancellation after N dispatches
+5. Digest rendering with and without PRs
+6. Notifier called when configured

--- a/.td/008-test-coverage-storage-runs.md
+++ b/.td/008-test-coverage-storage-runs.md
@@ -1,0 +1,21 @@
+# TD: HIGH — Add test coverage for internal/storage/runs.go filtering
+
+**Priority:** High
+**Category:** Test Coverage
+**Scope:** `internal/storage/runs.go`
+
+## Problem
+
+`storage/runs.go` has `ListRuns` with filter logic (by member, duty, status, limit) that
+builds dynamic SQL. The existing `storage_test.go` tests basic CRUD but does not exercise
+the filter combinations. Regressions in the SQL construction (see TD-005) would go
+undetected.
+
+## Suggested Tests
+
+Create or extend `internal/storage/runs_test.go`:
+1. Insert 10+ runs with varied member/duty/status values
+2. Test each filter individually (member only, duty only, status only, limit only)
+3. Test filter combinations (member + duty, status + limit)
+4. Test empty results (no matches)
+5. Test default behavior (no filters → all runs, ordered by started_at DESC)

--- a/.td/009-test-coverage-server-endpoints.md
+++ b/.td/009-test-coverage-server-endpoints.md
@@ -1,0 +1,25 @@
+# TD: MEDIUM — Add test coverage for server endpoints
+
+**Priority:** Medium
+**Category:** Test Coverage
+**Scope:** `internal/server/budget.go`, `internal/server/dashboard.go`, `internal/server/prs.go`, `internal/server/runs.go`, `internal/server/nights.go`
+
+## Problem
+
+Several server endpoints lack test coverage:
+- `budget.go` — budget snapshot API has no tests
+- `dashboard.go` — HTML dashboard rendering is untested
+- `prs.go` — PR listing endpoint has no tests
+- `runs.go` — `createRun` (POST) and `runsPage` (HTML) are untested
+- `nights.go` — `triggerNight` (POST) is untested
+
+The existing `server/*_test.go` files cover GET endpoints well but skip mutation
+endpoints and HTML page rendering.
+
+## Suggested Approach
+
+Follow the existing pattern in `server/runs_test.go` and `server/nights_test.go`:
+- Use `httptest.NewRecorder` + `httptest.NewRequest`
+- Wire up the server with in-memory storage and mock provider
+- Test success paths, validation errors, and 404s
+- For HTML pages, assert status 200 and spot-check response body for key strings

--- a/.td/010-test-coverage-provider-ulid.md
+++ b/.td/010-test-coverage-provider-ulid.md
@@ -1,0 +1,23 @@
+# TD: MEDIUM — Add test coverage for provider/status.go and ulid/ulid.go
+
+**Priority:** Medium
+**Category:** Test Coverage
+**Scope:** `internal/provider/status.go`, `internal/ulid/ulid.go`
+
+## Problem
+
+- `provider/status.go` — No tests for the session status probing logic. When real
+  provider status is implemented (see TD-003), tests will be essential to verify
+  parsing and error handling.
+
+- `ulid/ulid.go` — No test file exists. The ULID generation is used as the primary key
+  for nights and runs. While the implementation is likely a thin wrapper, tests should
+  verify:
+  - Output format (prefix + ULID body)
+  - Uniqueness across rapid successive calls
+  - Monotonicity (lexical sort = temporal sort)
+
+## Suggested Approach
+
+Create `internal/provider/status_test.go` and `internal/ulid/ulid_test.go` with basic
+property tests.

--- a/.td/011-test-coverage-utility-files.md
+++ b/.td/011-test-coverage-utility-files.md
@@ -1,0 +1,20 @@
+# TD: LOW — Add test coverage for gitops/files.go and version/version.go
+
+**Priority:** Low
+**Category:** Test Coverage
+**Scope:** `internal/gitops/files.go`, `internal/version/version.go`
+
+## Problem
+
+- `gitops/files.go` — File manipulation helpers for git operations. `gitops_test.go`
+  exists but may not cover `files.go` specifically. Verify coverage and add tests for
+  any uncovered functions.
+
+- `version/version.go` — Build-time version injection. No test file exists. While
+  simple, a test ensures the linker flags work correctly and the version string format
+  is stable for CLI output and API responses.
+
+## Suggested Approach
+
+Low priority — address when touching these files for other reasons. A single test per
+file exercising the happy path is sufficient.

--- a/cmd/nf/duty.go
+++ b/cmd/nf/duty.go
@@ -65,7 +65,9 @@ func dutyList(args []string) {
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
 			d.Type, d.Output, d.CostTier, d.Risk, d.Description)
 	}
-	_ = tw.Flush()
+	if err := tw.Flush(); err != nil {
+		fmt.Fprintln(os.Stderr, "nf:", err)
+	}
 }
 
 func dutyShow(args []string) {

--- a/cmd/nf/family.go
+++ b/cmd/nf/family.go
@@ -148,7 +148,9 @@ func familyList(args []string) {
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%d\t%s\n",
 			m.Name, m.RiskTolerance, m.CostTier, duties, m.Role)
 	}
-	_ = tw.Flush()
+	if err := tw.Flush(); err != nil {
+		fmt.Fprintln(os.Stderr, "nf:", err)
+	}
 }
 
 func familyShow(args []string) {

--- a/cmd/nf/night.go
+++ b/cmd/nf/night.go
@@ -56,7 +56,10 @@ func nightList(_ []string) {
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "ID\tSTARTED\tFINISHED\tSUMMARY")
 	for _, it := range items {
-		m := it.(map[string]any)
+		m, ok := it.(map[string]any)
+		if !ok {
+			continue
+		}
 		started, _ := m["started_at"].(string)
 		finished, _ := m["finished_at"].(string)
 		if finished == "" {
@@ -65,7 +68,9 @@ func nightList(_ []string) {
 		summary, _ := m["summary"].(string)
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\n", m["id"], started, finished, summary)
 	}
-	_ = tw.Flush()
+	if err := tw.Flush(); err != nil {
+		fmt.Fprintln(os.Stderr, "nf:", err)
+	}
 }
 
 func nightShow(args []string) {
@@ -181,7 +186,9 @@ func nightPreview(args []string) {
 		fmt.Fprintf(tw, "%d\t%s\t%s\t%s\t%s\t%s\t%s\t%d\n",
 			i+1, s.Member, s.Duty, s.Priority, s.Output, s.CostTier, s.Risk, s.EstimatedTokens)
 	}
-	_ = tw.Flush()
+	if err := tw.Flush(); err != nil {
+		fmt.Fprintln(os.Stderr, "nf:", err)
+	}
 	if len(plan.Skipped) > 0 {
 		fmt.Println("\nSkipped:")
 		for _, sk := range plan.Skipped {

--- a/cmd/nf/pr.go
+++ b/cmd/nf/pr.go
@@ -54,9 +54,14 @@ func prList(args []string) {
 	tw := tabwriter.NewWriter(os.Stdout, 0, 0, 2, ' ', 0)
 	fmt.Fprintln(tw, "OPENED\tMEMBER\tDUTY\tSTATE\tURL")
 	for _, it := range items {
-		m := it.(map[string]any)
+		m, ok := it.(map[string]any)
+		if !ok {
+			continue
+		}
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\n",
 			m["opened_at"], m["member"], m["duty"], m["state"], m["url"])
 	}
-	_ = tw.Flush()
+	if err := tw.Flush(); err != nil {
+		fmt.Fprintln(os.Stderr, "nf:", err)
+	}
 }

--- a/cmd/nf/run.go
+++ b/cmd/nf/run.go
@@ -106,7 +106,9 @@ func runList(args []string) {
 		fmt.Fprintf(tw, "%s\t%s\t%s\t%s\t%s\t%s\n",
 			r.ID, r.Member, r.Duty, r.Status, r.StartedAt, pr)
 	}
-	_ = tw.Flush()
+	if err := tw.Flush(); err != nil {
+		fmt.Fprintln(os.Stderr, "nf:", err)
+	}
 }
 
 func runStart(args []string) {

--- a/internal/runner/night.go
+++ b/internal/runner/night.go
@@ -141,7 +141,11 @@ func (r *Runner) renderDigest(ctx context.Context, nightID string, runs []storag
 		r.deps.Logger.Warn("digest: get night failed", "err", err)
 		return ""
 	}
-	prs, _ := r.deps.Storage.ListPRs(ctx, 200)
+	prs, err := r.deps.Storage.ListPRs(ctx, 200)
+	if err != nil {
+		r.deps.Logger.Warn("digest: list PRs failed", "err", err)
+		return ""
+	}
 	byRun := map[string]bool{}
 	for _, rn := range runs {
 		byRun[rn.ID] = true

--- a/internal/scheduler/loop.go
+++ b/internal/scheduler/loop.go
@@ -42,7 +42,7 @@ type Loop struct {
 	opts     Options
 	mu       sync.Mutex
 	lastFire time.Time
-	running  bool
+	once     sync.Once
 }
 
 // New returns a Loop ready to be Start()-ed.
@@ -58,14 +58,9 @@ func New(opts Options) *Loop {
 
 // Start spawns the loop. Safe to call twice — second call is a no-op.
 func (l *Loop) Start(ctx context.Context) {
-	l.mu.Lock()
-	if l.running {
-		l.mu.Unlock()
-		return
-	}
-	l.running = true
-	l.mu.Unlock()
-	go l.run(ctx)
+	l.once.Do(func() {
+		go l.run(ctx)
+	})
 }
 
 // LastFire returns the wall time of the most recent auto-fire, or

--- a/internal/server/nights.go
+++ b/internal/server/nights.go
@@ -67,9 +67,10 @@ func (s *Server) triggerNight(w http.ResponseWriter, r *http.Request) {
 			return
 		}
 	}
-	// Give the night a generous ceiling; individual mock runs are
-	// ~20ms each, so a full plan finishes well inside this.
-	ctx, cancel := context.WithTimeout(context.Background(), 10*time.Minute)
+	// Derive from the request context so that client cancellation
+	// propagates. The generous ceiling covers full plans; individual
+	// mock runs are ~20ms each, so they finish well inside this.
+	ctx, cancel := context.WithTimeout(r.Context(), 10*time.Minute)
 	defer cancel()
 	res, err := s.cfg.Runner.TriggerNight(ctx, s.cfg.Schedule, runner.NightOptions{
 		OnlyMembers: req.OnlyMembers,

--- a/internal/server/runs.go
+++ b/internal/server/runs.go
@@ -40,11 +40,11 @@ func (s *Server) createRun(w http.ResponseWriter, r *http.Request) {
 		writeProblem(w, http.StatusBadRequest, "bad_request", "member and duty are required", r.URL.Path)
 		return
 	}
-	// Use a detached context with a generous timeout so the handler
-	// returns the final (not merely queued) run once the mock
-	// finishes. When providers get expensive we'll flip this to
-	// async + 202 Accepted.
-	ctx, cancel := context.WithTimeout(context.Background(), 2*time.Minute)
+	// Derive from the request context so that client cancellation
+	// propagates. The generous timeout ensures the handler returns
+	// the final (not merely queued) run once the mock finishes.
+	// When providers get expensive we'll flip this to async + 202 Accepted.
+	ctx, cancel := context.WithTimeout(r.Context(), 2*time.Minute)
 	defer cancel()
 	run, err := s.cfg.Runner.Dispatch(ctx, runner.DispatchRequest{
 		Member: req.Member, Duty: req.Duty, Args: req.Args,

--- a/internal/storage/storage.go
+++ b/internal/storage/storage.go
@@ -108,13 +108,17 @@ func (db *DB) migrate(ctx context.Context) error {
 	return nil
 }
 
-func (db *DB) applyMigration(ctx context.Context, name, sqlText string) error {
+func (db *DB) applyMigration(ctx context.Context, name, sqlText string) (err error) {
 	tx, err := db.raw.BeginTx(ctx, nil)
 	if err != nil {
 		return err
 	}
-	defer func() { _ = tx.Rollback() }()
-	if _, err := tx.ExecContext(ctx, sqlText); err != nil {
+	defer func() {
+		if err != nil {
+			_ = tx.Rollback()
+		}
+	}()
+	if _, err = tx.ExecContext(ctx, sqlText); err != nil {
 		return err
 	}
 	return tx.Commit()


### PR DESCRIPTION
## Summary

Technical debt review session (2026-04-22). Six obvious bugs fixed immediately, eleven deferred task files created for larger issues and missing test coverage.

### Bugs fixed (all tests pass)

- **context.Background() in HTTP handlers**: `server/runs.go` and `server/nights.go` used `context.Background()` for long-running dispatches, preventing request cancellation from propagating. Now derives from `r.Context()`.
- **Ignored ListPRs error**: `runner/night.go` silently discarded the error from `ListPRs`, masking DB failures during digest rendering. Now logs a warning and degrades gracefully.
- **Unsafe type assertions in CLI**: `cmd/nf/night.go` and `cmd/nf/pr.go` had bare `it.(map[string]any)` assertions that would panic on unexpected API responses. Now uses comma-ok guard.
- **Discarded tabwriter Flush errors**: 6 locations across CLI files silently dropped flush errors. Now reports them to stderr.
- **Scheduler Start() race guard**: `scheduler/loop.go` used manual mutex+bool for single-start. Replaced with idiomatic `sync.Once`.
- **Always-rollback in migrations**: `storage/storage.go` `applyMigration` called `tx.Rollback()` unconditionally via defer, even after successful commit. Now uses named return to only rollback on error.

### Deferred tasks created (`.td/`)

**Bigger issues (001–006):**
- 001: Systematic ignored JSON encoding errors across 20+ CLI locations
- 002: Silent DB errors in runner non-fatal operations
- 003: Stub SessionStatus in providers (Claude/Codex)
- 004: Missing token counting in provider implementations
- 005: Fragile SQL query construction in storage/runs.go
- 006: Missing config validation in config/config.go

**Missing test coverage (007–011):**
- 007: CRITICAL — `internal/runner/night.go` (core orchestration, no dedicated tests)
- 008: HIGH — `internal/storage/runs.go` filter logic
- 009: MEDIUM — Server mutation endpoints and HTML pages
- 010: MEDIUM — `provider/status.go` and `ulid/ulid.go`
- 011: LOW — `gitops/files.go` and `version/version.go`

## Test plan

- [x] `go build ./...` compiles cleanly
- [x] `go test ./...` — all existing tests pass
- [ ] Verify context cancellation propagates in manual testing of POST /api/v1/runs and POST /api/v1/nights/trigger
- [ ] Verify CLI handles malformed API responses gracefully (type assertion guards)

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: td-review:/var/home/bupd
task-type: td-review
task-title: TD Review Session
provider: claude
score: 3.0
cost-tier: High (150-500k)
iterations: 2
duration: 28m26s
run-started: 2026-04-22T00:00:00Z
nightshift:metadata -->
