### PR TITLE
feat: per-endpoint HTTP metrics and token counters

### DIFF
--- a/internal/server/collector.go
+++ b/internal/server/collector.go
@@ -1,0 +1,114 @@
+package server
+
+import (
+	"fmt"
+	"io"
+	"sort"
+	"sync"
+)
+
+// httpCollector tracks per-route HTTP request counts and cumulative
+// durations. It is goroutine-safe and intended to be populated by the
+// logging middleware and read by the /metrics handler.
+type httpCollector struct {
+	mu       sync.Mutex
+	counts   map[routeKey]int64
+	durSumMs map[durationKey]float64 // cumulative seconds
+}
+
+type routeKey struct {
+	method string
+	route  string
+	status int
+}
+
+type durationKey struct {
+	method string
+	route  string
+}
+
+func newHTTPCollector() *httpCollector {
+	return &httpCollector{
+		counts:   make(map[routeKey]int64),
+		durSumMs: make(map[durationKey]float64),
+	}
+}
+
+// record is called once per completed request.
+func (c *httpCollector) record(method, route string, status int, durationSec float64) {
+	c.mu.Lock()
+	c.counts[routeKey{method, route, status}]++
+	c.durSumMs[durationKey{method, route}] += durationSec
+	c.mu.Unlock()
+}
+
+// writePrometheus writes nf_http_requests_total and
+// nf_http_request_duration_seconds metrics in Prometheus text format.
+func (c *httpCollector) writePrometheus(w io.Writer) {
+	c.mu.Lock()
+	// snapshot under lock
+	counts := make([]struct {
+		k routeKey
+		v int64
+	}, 0, len(c.counts))
+	for k, v := range c.counts {
+		counts = append(counts, struct {
+			k routeKey
+			v int64
+		}{k, v})
+	}
+	durations := make([]struct {
+		k durationKey
+		v float64
+	}, 0, len(c.durSumMs))
+	for k, v := range c.durSumMs {
+		durations = append(durations, struct {
+			k durationKey
+			v float64
+		}{k, v})
+	}
+	c.mu.Unlock()
+
+	if len(counts) > 0 {
+		sort.Slice(counts, func(i, j int) bool {
+			a, b := counts[i].k, counts[j].k
+			if a.method != b.method {
+				return a.method < b.method
+			}
+			if a.route != b.route {
+				return a.route < b.route
+			}
+			return a.status < b.status
+		})
+		fmt.Fprintf(w, "# HELP nf_http_requests_total Total HTTP requests by method, route, and status.\n")
+		fmt.Fprintf(w, "# TYPE nf_http_requests_total counter\n")
+		for _, e := range counts {
+			fmt.Fprintf(w, "nf_http_requests_total{method=%q,route=%q,status=\"%d\"} %d\n",
+				e.k.method, e.k.route, e.k.status, e.v)
+		}
+	}
+
+	if len(durations) > 0 {
+		sort.Slice(durations, func(i, j int) bool {
+			a, b := durations[i].k, durations[j].k
+			if a.method != b.method {
+				return a.method < b.method
+			}
+			return a.route < b.route
+		})
+		fmt.Fprintf(w, "# HELP nf_http_request_duration_seconds Cumulative HTTP request duration in seconds.\n")
+		fmt.Fprintf(w, "# TYPE nf_http_request_duration_seconds summary\n")
+		for _, e := range durations {
+			var total int64
+			for _, c := range counts {
+				if c.k.method == e.k.method && c.k.route == e.k.route {
+					total += c.v
+				}
+			}
+			fmt.Fprintf(w, "nf_http_request_duration_seconds_count{method=%q,route=%q} %d\n",
+				e.k.method, e.k.route, total)
+			fmt.Fprintf(w, "nf_http_request_duration_seconds_sum{method=%q,route=%q} %f\n",
+				e.k.method, e.k.route, e.v)
+		}
+	}
+}

--- a/internal/server/metrics.go
+++ b/internal/server/metrics.go
@@ -33,6 +33,10 @@ func (s *Server) metrics(w http.ResponseWriter, r *http.Request) {
 	fmt.Fprintf(w, "# TYPE nf_uptime_seconds counter\n")
 	fmt.Fprintf(w, "nf_uptime_seconds %f\n", time.Since(bootedAt).Seconds())
 
+	if s.collector != nil {
+		s.collector.writePrometheus(w)
+	}
+
 	if s.cfg.Storage == nil {
 		return
 	}
@@ -67,4 +71,12 @@ func (s *Server) metrics(w http.ResponseWriter, r *http.Request) {
 	for state, n := range stats.PRsByState {
 		fmt.Fprintf(w, "nf_prs_by_state{state=%q} %d\n", state, n)
 	}
+
+	fmt.Fprintf(w, "# HELP nf_tokens_in_total Total input tokens consumed across all runs.\n")
+	fmt.Fprintf(w, "# TYPE nf_tokens_in_total counter\n")
+	fmt.Fprintf(w, "nf_tokens_in_total %d\n", stats.TokensIn)
+
+	fmt.Fprintf(w, "# HELP nf_tokens_out_total Total output tokens produced across all runs.\n")
+	fmt.Fprintf(w, "# TYPE nf_tokens_out_total counter\n")
+	fmt.Fprintf(w, "nf_tokens_out_total %d\n", stats.TokensOut)
 }

--- a/internal/server/metrics_test.go
+++ b/internal/server/metrics_test.go
@@ -41,9 +41,12 @@ func TestMetricsIncludesStorageCounts(t *testing.T) {
 		t.Fatalf("Open: %v", err)
 	}
 	t.Cleanup(func() { _ = db.Close() })
+	tokIn := 500
+	tokOut := 120
 	_ = db.InsertRun(context.Background(), storage.Run{
 		ID: "run_01HMETRICS0000000000000000", Member: "rick", Duty: "vuln-scan",
 		Status: storage.RunSucceeded, StartedAt: time.Now(),
+		TokensIn: &tokIn, TokensOut: &tokOut,
 	})
 	s, _ := New(Config{
 		Addr: "127.0.0.1:0", Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
@@ -56,6 +59,37 @@ func TestMetricsIncludesStorageCounts(t *testing.T) {
 	for _, want := range []string{
 		"nf_runs_total 1",
 		`nf_runs_by_status{status="succeeded"} 1`,
+		"nf_tokens_in_total 500",
+		"nf_tokens_out_total 120",
+	} {
+		if !strings.Contains(body, want) {
+			t.Errorf("body missing %q\n--- full body ---\n%s", want, body)
+		}
+	}
+}
+
+func TestMetricsIncludesHTTPCounters(t *testing.T) {
+	s, _ := New(Config{
+		Addr:   "127.0.0.1:0",
+		Logger: slog.New(slog.NewTextHandler(io.Discard, nil)),
+	})
+	handler := s.routes()
+
+	// Hit several routes to populate the collector.
+	for _, path := range []string{"/healthz", "/healthz", "/version"} {
+		rr := httptest.NewRecorder()
+		handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, path, nil))
+	}
+
+	// Now fetch /metrics and verify per-endpoint counters.
+	rr := httptest.NewRecorder()
+	handler.ServeHTTP(rr, httptest.NewRequest(http.MethodGet, "/metrics", nil))
+	body := rr.Body.String()
+
+	for _, want := range []string{
+		`nf_http_requests_total{method="GET",route=`,
+		`nf_http_request_duration_seconds_sum{method="GET",route=`,
+		`nf_http_request_duration_seconds_count{method="GET",route=`,
 	} {
 		if !strings.Contains(body, want) {
 			t.Errorf("body missing %q\n--- full body ---\n%s", want, body)

--- a/internal/server/server.go
+++ b/internal/server/server.go
@@ -71,6 +71,7 @@ type Server struct {
 	dashCardTpl *template.Template
 	web         fs.FS
 	spec        *specBundle
+	collector   *httpCollector
 }
 
 // New constructs a Server. Templates are parsed eagerly; if parsing fails
@@ -95,7 +96,7 @@ func New(cfg Config) (*Server, error) {
 	if err != nil {
 		return nil, err
 	}
-	s := &Server{cfg: cfg, pages: pages, dashCardTpl: dashTpl, web: web, spec: spec}
+	s := &Server{cfg: cfg, pages: pages, dashCardTpl: dashTpl, web: web, spec: spec, collector: newHTTPCollector()}
 	s.srv = &http.Server{
 		Addr:              cfg.Addr,
 		Handler:           s.routes(),
@@ -151,7 +152,7 @@ func (s *Server) routes() http.Handler {
 		mux.Handle("GET /static/", http.StripPrefix("/static/", http.FileServerFS(staticSub)))
 	}
 
-	return logMiddleware(s.cfg.Logger, mux)
+	return logMiddleware(s.cfg.Logger, s.collector, mux)
 }
 
 func (s *Server) healthz(w http.ResponseWriter, _ *http.Request) {
@@ -232,17 +233,25 @@ func writeJSON(w http.ResponseWriter, status int, v any) {
 	_ = json.NewEncoder(w).Encode(v)
 }
 
-func logMiddleware(logger *slog.Logger, next http.Handler) http.Handler {
+func logMiddleware(logger *slog.Logger, col *httpCollector, next http.Handler) http.Handler {
 	return http.HandlerFunc(func(w http.ResponseWriter, r *http.Request) {
 		start := time.Now()
 		rw := &statusRecorder{ResponseWriter: w, status: 200}
 		next.ServeHTTP(rw, r)
+		dur := time.Since(start)
+		route := r.Pattern
+		if route == "" {
+			route = r.URL.Path
+		}
 		logger.Info("http",
 			"method", r.Method,
 			"path", r.URL.Path,
 			"status", rw.status,
-			"dur", time.Since(start).String(),
+			"dur", dur.String(),
 		)
+		if col != nil {
+			col.record(r.Method, route, rw.status, dur.Seconds())
+		}
 	})
 }
 

--- a/internal/storage/stats.go
+++ b/internal/storage/stats.go
@@ -12,6 +12,8 @@ type Stats struct {
 	RunsByStatus map[string]int `json:"runs_by_status"`
 	PRs          int            `json:"prs"`
 	PRsByState   map[string]int `json:"prs_by_state"`
+	TokensIn     int64          `json:"tokens_in"`
+	TokensOut    int64          `json:"tokens_out"`
 }
 
 // Stats returns a single-query snapshot.
@@ -57,5 +59,10 @@ func (db *DB) Stats(ctx context.Context) (Stats, error) {
 		s.PRsByState[st] = n
 	}
 	rows.Close()
+
+	_ = db.raw.QueryRowContext(ctx,
+		`SELECT COALESCE(SUM(tokens_in),0), COALESCE(SUM(tokens_out),0) FROM runs`,
+	).Scan(&s.TokensIn, &s.TokensOut)
+
 	return s, nil
 }


### PR DESCRIPTION
## Summary
- Add in-memory `httpCollector` (mutex-guarded maps, no new deps) that the logging middleware populates with method/route/status/duration per request
- Extend `/metrics` to emit `nf_http_requests_total{method,route,status}` and `nf_http_request_duration_seconds{method,route}` counters
- Add `nf_tokens_in_total` and `nf_tokens_out_total` from DB aggregates (`SUM(tokens_in/out)` on the runs table)
- Add `TokensIn`/`TokensOut` fields to `storage.Stats` struct

## Test plan
- [x] `TestMetricsIncludesHTTPCounters` — exercises several routes then asserts per-endpoint counters appear in `/metrics` output
- [x] `TestMetricsIncludesStorageCounts` — extended to verify `nf_tokens_in_total` and `nf_tokens_out_total`
- [x] `go test ./...` passes
- [x] `go vet ./...` clean

Nightshift-Task: metrics-coverage
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: metrics-coverage:/var/home/bupd
task-type: metrics-coverage
task-title: Metrics Coverage Analyzer
provider: claude
score: 3.0
cost-tier: Medium (50-150k)
iterations: 2
duration: 15m0s
run-started: 2026-04-24T00:00:42Z
nightshift:metadata -->
