### PR TITLE
build: parallelize Go builds and split CI into parallel jobs

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -14,8 +14,8 @@ concurrency:
   cancel-in-progress: true
 
 jobs:
-  check:
-    name: vet / test / build
+  lint:
+    name: lint
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
@@ -39,13 +39,29 @@ jobs:
       - name: go vet
         run: go vet ./...
 
+  test-build:
+    name: test / build
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - name: Set up Go
+        uses: actions/setup-go@v5
+        with:
+          go-version: 'stable'
+          check-latest: true
+          cache: true
+
+      - name: Download modules
+        run: go mod download
+
       - name: go test
         run: go test -race ./...
 
       - name: go build
         run: |
-          go build -o /tmp/nf ./cmd/nf
-          go build -o /tmp/nfd ./cmd/nfd
+          go build -trimpath -o /tmp/nf ./cmd/nf
+          go build -trimpath -o /tmp/nfd ./cmd/nfd
 
       - name: smoke test nfd
         run: |

--- a/Taskfile.yml
+++ b/Taskfile.yml
@@ -23,10 +23,13 @@ tasks:
 
   build:
     desc: Build nf and nfd into ./bin
+    deps: [_build-nf, _build-nfd]
+    method: checksum
+
+  _build-nf:
+    internal: true
     deps: [_mkbin]
-    cmds:
-      - go build -ldflags '{{.LDFLAGS}}' -o {{.BIN_DIR}}/nf ./cmd/nf
-      - go build -ldflags '{{.LDFLAGS}}' -o {{.BIN_DIR}}/nfd ./cmd/nfd
+    cmd: go build -trimpath -ldflags '{{.LDFLAGS}}' -o {{.BIN_DIR}}/nf ./cmd/nf
     sources:
       - '**/*.go'
       - 'internal/server/web/**/*'
@@ -35,7 +38,21 @@ tasks:
       - 'go.sum'
     generates:
       - '{{.BIN_DIR}}/nf'
+    method: checksum
+
+  _build-nfd:
+    internal: true
+    deps: [_mkbin]
+    cmd: go build -trimpath -ldflags '{{.LDFLAGS}}' -o {{.BIN_DIR}}/nfd ./cmd/nfd
+    sources:
+      - '**/*.go'
+      - 'internal/server/web/**/*'
+      - 'internal/server/apiassets/**/*'
+      - 'go.mod'
+      - 'go.sum'
+    generates:
       - '{{.BIN_DIR}}/nfd'
+    method: checksum
 
   _mkbin:
     internal: true


### PR DESCRIPTION
## Summary
- **Taskfile**: Split `nf` and `nfd` builds into two internal sub-tasks (`_build-nf`, `_build-nfd`) run as concurrent `deps` instead of sequential `cmds`. Added `-trimpath` flag and `method: checksum` for faster incremental rebuilds.
- **CI**: Split single `check` job into parallel `lint` (gofmt + vet) and `test-build` (test + build + smoke-test) jobs. Added explicit `go mod download` step and `-trimpath` to build commands.

## Test plan
- [x] `go test -race ./...` passes locally
- [ ] CI lint job passes (gofmt + vet)
- [ ] CI test-build job passes (test + build + smoke-test)

Nightshift-Task: build-optimize
Nightshift-Ref: https://github.com/marcus/nightshift

🤖 Generated with [Claude Code](https://claude.com/claude-code)


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: build-optimize:/var/home/bupd
task-type: build-optimize
task-title: Build Time Optimization
provider: claude
score: 3.0
cost-tier: High (150-500k)
iterations: 1
duration: 4m38s
run-started: 2026-04-27T00:00:00Z
nightshift:metadata -->
