### PR TITLE
fix: handle discarded errors and harden SQL queries

### DIFF
--- a/internal/notify/slack.go
+++ b/internal/notify/slack.go
@@ -56,7 +56,10 @@ func (s *Slack) Notify(ctx context.Context, title, body string) error {
 		body = body[:3000] + "\n…(truncated)"
 	}
 	payload := map[string]string{"text": title + "\n\n" + body}
-	raw, _ := json.Marshal(payload)
+	raw, err := json.Marshal(payload)
+	if err != nil {
+		return fmt.Errorf("slack: marshal payload: %w", err)
+	}
 
 	cctx, cancel := context.WithTimeout(ctx, s.Timeout)
 	defer cancel()

--- a/internal/runner/night.go
+++ b/internal/runner/night.go
@@ -54,7 +54,10 @@ func (r *Runner) TriggerNight(ctx context.Context, sched *schedule.Schedule, opt
 	nightID := ulid.Make("night")
 	started := time.Now().UTC()
 
-	planJSON, _ := json.Marshal(plan)
+	planJSON, err := json.Marshal(plan)
+	if err != nil {
+		return NightResult{}, fmt.Errorf("runner: marshal plan: %w", err)
+	}
 	if err := r.deps.Storage.InsertNight(ctx, storage.Night{
 		ID:        nightID,
 		StartedAt: started,

--- a/internal/server/digest.go
+++ b/internal/server/digest.go
@@ -49,7 +49,11 @@ func (s *Server) getNightDigest(w http.ResponseWriter, r *http.Request) {
 		}
 	}
 
-	prs, _ := s.cfg.Storage.ListPRs(ctx, 500)
+	prs, err := s.cfg.Storage.ListPRs(ctx, 500)
+	if err != nil {
+		writeProblem(w, http.StatusInternalServerError, "db_error", err.Error(), r.URL.Path)
+		return
+	}
 	byRun := map[string]bool{}
 	for _, rn := range filtered {
 		byRun[rn.ID] = true

--- a/internal/server/digest_page.go
+++ b/internal/server/digest_page.go
@@ -50,14 +50,22 @@ func (s *Server) digestPage(w http.ResponseWriter, r *http.Request) {
 		http.Error(w, err.Error(), http.StatusInternalServerError)
 		return
 	}
-	runs, _ := s.cfg.Storage.ListRuns(ctx, storage.ListRunsFilter{Limit: 500})
+	runs, err := s.cfg.Storage.ListRuns(ctx, storage.ListRunsFilter{Limit: 500})
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	filtered := runs[:0]
 	for _, rn := range runs {
 		if rn.NightID != nil && *rn.NightID == id {
 			filtered = append(filtered, rn)
 		}
 	}
-	prs, _ := s.cfg.Storage.ListPRs(ctx, 500)
+	prs, err := s.cfg.Storage.ListPRs(ctx, 500)
+	if err != nil {
+		http.Error(w, err.Error(), http.StatusInternalServerError)
+		return
+	}
 	byRun := map[string]bool{}
 	for _, rn := range filtered {
 		byRun[rn.ID] = true

--- a/internal/storage/nights.go
+++ b/internal/storage/nights.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"time"
 )
 
@@ -68,9 +67,9 @@ func (db *DB) ListNights(ctx context.Context, limit int) ([]Night, error) {
 	if limit <= 0 || limit > 500 {
 		limit = 50
 	}
-	rows, err := db.raw.QueryContext(ctx, fmt.Sprintf(`
+	rows, err := db.raw.QueryContext(ctx, `
 		SELECT id, started_at, finished_at, plan_json, summary
-		FROM nights ORDER BY started_at DESC LIMIT %d`, limit))
+		FROM nights ORDER BY started_at DESC LIMIT ?`, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/prs.go
+++ b/internal/storage/prs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"time"
 )
 
@@ -58,9 +57,9 @@ func (db *DB) ListPRs(ctx context.Context, limit int) ([]PR, error) {
 	if limit <= 0 || limit > 500 {
 		limit = 50
 	}
-	rows, err := db.raw.QueryContext(ctx, fmt.Sprintf(`
+	rows, err := db.raw.QueryContext(ctx, `
 		SELECT id, run_id, url, title, member, duty, opened_at, merged_at, state
-		FROM prs ORDER BY opened_at DESC LIMIT %d`, limit))
+		FROM prs ORDER BY opened_at DESC LIMIT ?`, limit)
 	if err != nil {
 		return nil, err
 	}

--- a/internal/storage/runs.go
+++ b/internal/storage/runs.go
@@ -4,7 +4,6 @@ import (
 	"context"
 	"database/sql"
 	"errors"
-	"fmt"
 	"time"
 )
 
@@ -105,7 +104,8 @@ func (db *DB) ListRuns(ctx context.Context, f ListRunsFilter) ([]Run, error) {
 	if f.Limit <= 0 || f.Limit > 500 {
 		f.Limit = 50
 	}
-	q += fmt.Sprintf(" LIMIT %d", f.Limit)
+	q += " LIMIT ?"
+	args = append(args, f.Limit)
 	rows, err := db.raw.QueryContext(ctx, q, args...)
 	if err != nil {
 		return nil, err

--- a/internal/storage/stats.go
+++ b/internal/storage/stats.go
@@ -33,29 +33,33 @@ func (db *DB) Stats(ctx context.Context) (Stats, error) {
 	if err != nil {
 		return s, err
 	}
+	defer rows.Close()
 	for rows.Next() {
 		var st string
 		var n int
 		if err := rows.Scan(&st, &n); err != nil {
-			rows.Close()
 			return s, err
 		}
 		s.RunsByStatus[st] = n
 	}
-	rows.Close()
-	rows, err = db.raw.QueryContext(ctx, `SELECT state, COUNT(*) FROM prs GROUP BY state`)
+	if err := rows.Err(); err != nil {
+		return s, err
+	}
+	rows2, err := db.raw.QueryContext(ctx, `SELECT state, COUNT(*) FROM prs GROUP BY state`)
 	if err != nil {
 		return s, err
 	}
-	for rows.Next() {
+	defer rows2.Close()
+	for rows2.Next() {
 		var st string
 		var n int
-		if err := rows.Scan(&st, &n); err != nil {
-			rows.Close()
+		if err := rows2.Scan(&st, &n); err != nil {
 			return s, err
 		}
 		s.PRsByState[st] = n
 	}
-	rows.Close()
+	if err := rows2.Err(); err != nil {
+		return s, err
+	}
 	return s, nil
 }


### PR DESCRIPTION
## Summary
- **stats.go**: Add missing `rows.Err()` checks after both iteration loops and use `defer rows.Close()` for safer resource cleanup — silent data loss on iteration failure
- **digest_page.go**: Handle `ListRuns` (line 53) and `ListPRs` (line 60) errors instead of silently discarding — page was serving incomplete data without error indication
- **digest.go**: Handle `ListPRs` error instead of silently discarding with `_ =`
- **night.go**: Propagate `json.Marshal` error for plan — failure would store `null` as the plan in the DB
- **slack.go**: Propagate `json.Marshal` error — failure could send broken/empty JSON to webhook
- **runs.go, nights.go, prs.go**: Use parameterized queries (`?`) for LIMIT instead of `fmt.Sprintf` — avoids SQL anti-pattern

## Test plan
- [x] `go vet ./...` passes
- [x] `go test -race ./...` passes (all packages)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

Nightshift-Task: bug-finder
Nightshift-Ref: https://github.com/marcus/nightshift


---
*Automated by [nightshift](https://github.com/marcus/nightshift)*

<!-- nightshift:metadata
task-id: bug-finder:/var/home/bupd
task-type: bug-finder
task-title: Bug Finder & Fixer
provider: claude
score: 3.0
cost-tier: High (150-500k)
iterations: 3
duration: 18m2s
run-started: 2026-05-04T00:00:00Z
nightshift:metadata -->
